### PR TITLE
Add badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,15 @@
+.. image:: https://img.shields.io/pypi/v/dwave-gate.svg
+    :target: https://pypi.org/project/dwave-gate
+
+.. image:: https://img.shields.io/pypi/pyversions/dwave-gate.svg
+    :target: https://pypi.org/project/dwave-gate
+
+.. image:: https://circleci.com/gh/dwavesystems/dwave-gate.svg?style=svg
+    :target: https://circleci.com/gh/dwavesystems/dwave-gate
+
+.. image:: https://codecov.io/gh/dwavesystems/dwave-gate/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/dwavesystems/dwave-gate
+
 dwave-gate
 ==========
 

--- a/dwave/gate/utils.py
+++ b/dwave/gate/utils.py
@@ -3,7 +3,7 @@ from typing import _GenericAlias
 
 try:
     from functools import cached_property
-except ImportError:
+except ImportError:  # pragma: no cover
 
     # Copyright (C) 2006-2013 Python Software Foundation.
     _NOT_FOUND = object()


### PR DESCRIPTION
* Add badges for PyPI, Python, Codecov and CircleCI.
* Ignore coverage for `cached_property`. Already tested with Python 3.7 tests.