### PR TITLE
Update context manager to return a `NamedTuple`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ a two-qubit circuit.
 
     circuit = Circuit(2)
 
-    with circuit.context as q:
+    with circuit.context as (q, c):
         ops.Hadamard(q[1])
         ops.CZ(q[0], q[1])
         ops.Hadamard(q[1])

--- a/dwave/gate/circuit.py
+++ b/dwave/gate/circuit.py
@@ -23,7 +23,6 @@ __all__ = [
 ]
 
 import copy
-from dwave.gate.utils import cached_property
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -33,6 +32,7 @@ from typing import (
     Hashable,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Sequence,
     Tuple,
@@ -47,6 +47,7 @@ from dwave.gate.registers.registers import (
     QuantumRegister,
     SelfIncrementingRegister,
 )
+from dwave.gate.utils import cached_property
 
 if TYPE_CHECKING:
     from dwave.gate.operations.base import Operation
@@ -190,7 +191,7 @@ class Circuit:
         del self.circuit[idx]
 
     @cached_property
-    def qubits(self) -> Sequence[Qubit]:
+    def qubits(self) -> QuantumRegister:
         """Qubits handled by the circuit."""
         qubit_reg = QuantumRegister()
         for qreg in self.qregisters.values():
@@ -199,7 +200,7 @@ class Circuit:
         return qubit_reg
 
     @cached_property
-    def bits(self) -> Sequence[Bit]:
+    def bits(self) -> ClassicalRegister:
         """Classical bits handled by the circuit."""
         bit_reg = ClassicalRegister()
         for creg in self.cregisters.values():
@@ -231,7 +232,14 @@ class Circuit:
 
     @property
     def context(self) -> CircuitContext:
-        """Circuit context used to apply operations to the circuit."""
+        """Circuit context used to apply operations to the circuit.
+
+        A :class:`dwave.gate.circuit.Registers` is returned when entering the context, which
+        contains the quantum and classical registers, named ``q`` and ``c`` respectively. These
+        contain all qubits and classical bits respectively and can be used to reference operation
+        applications and measurement values. All operations initialized within the context are
+        automatically applied to the circuit unless called within a frozen context.
+        """
         if self._circuit_context is None:
             self._circuit_context = CircuitContext(circuit=self)
         return self._circuit_context
@@ -572,6 +580,10 @@ class ParametricCircuit(Circuit):
         raise CircuitError("Parametric circuits cannot be transpiled into OpenQASM.")
 
 
+Registers = NamedTuple("Registers", [("q", QuantumRegister), ("c", ClassicalRegister)])
+"""NamedTuple: collection of registers returned from the context manager."""
+
+
 class CircuitContext:
     """Class used to handle and store the active context.
 
@@ -602,8 +614,8 @@ class CircuitContext:
     def freeze(cls) -> ContextManager:
         """Freeze the context so that no operations are appended on initialization.
 
-        Returns a context manager for a context in which any initialized gates won't be
-        appended to the active circuit context.
+        Returns a context manager for a context in which any initialized gates won't be appended to
+        the active circuit context.
 
         Returns:
             ContextManager: Manager for context withing no opperations are appended.
@@ -620,7 +632,7 @@ class CircuitContext:
 
                 >>> circuit = Circuit(1)
 
-                >>> with circuit.context as q:
+                >>> with circuit.context as (q, c):
                 ...   X(q[0])  # will be appended to the circuit
                 ...   with circuit.context.freeze:
                 ...       Y(q[0])  # will NOT be appended to the circuit
@@ -644,7 +656,7 @@ class CircuitContext:
 
     def __enter__(
         self,
-    ) -> Sequence[Qubit]:
+    ) -> Registers:
         """Enters the context and sets itself as active."""
         if self.circuit.is_locked() == True:
             raise CircuitError(
@@ -656,7 +668,8 @@ class CircuitContext:
             CircuitContext._active_context = self
         else:
             raise RuntimeError("Cannot enter context, another circuit context is already active.")
-        return self.circuit.qubits
+
+        return Registers(self.circuit.qubits, self.circuit.bits)
 
     def __exit__(
         self,
@@ -681,6 +694,13 @@ class CircuitContext:
         return cls._active_context
 
 
+ParametricRegisters = NamedTuple(
+    "ParametricRegisters",
+    [("p", SelfIncrementingRegister), ("q", QuantumRegister), ("c", ClassicalRegister)],
+)
+"""NamedTuple: collection of registers returned from the parametric context manager."""
+
+
 class ParametricCircuitContext(CircuitContext):
     """Class used to handle and store the active context with parametric circuits.
 
@@ -696,13 +716,14 @@ class ParametricCircuitContext(CircuitContext):
 
     def __enter__(
         self,
-    ) -> Tuple[SelfIncrementingRegister, Sequence[Qubit]]:
+    ) -> ParametricRegisters:
         """Enters the context and sets itself as active."""
         # should always be a 'ParametricCircuit'; check in '__init__'
         assert isinstance(self.circuit, ParametricCircuit)
 
-        q = super().__enter__()
-        return (self.circuit._parameter_register, q)
+        qreg, creg = super().__enter__()
+
+        return ParametricRegisters(self.circuit._parameter_register, qreg, creg)
 
     def __exit__(
         self,

--- a/dwave/gate/registers/registers.py
+++ b/dwave/gate/registers/registers.py
@@ -22,10 +22,22 @@ __all__ = [
     "SelfIncrementingRegister",
 ]
 
-from typing import AbstractSet, Hashable, Optional, Sequence, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Hashable,
+    Iterator,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 from dwave.gate.primitives import Bit, Qubit, Variable
 from dwave.gate.registers.cyregister import cyRegister
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 Data = TypeVar("Data", bound=Hashable)
 
@@ -44,6 +56,14 @@ class Register(cyRegister, AbstractSet[Data], Sequence[Data]):
     def __init__(self, data: Optional[Sequence[Data]] = None) -> None:
         self._frozen = False
         super().__init__(data or [])
+
+    def __getitem__(self, idx) -> Data:
+        """Get item at index."""
+        return super().__getitem__(idx)  # type: ignore
+
+    def __iter__(self) -> Iterator[Data]:
+        """Return a data iterator."""
+        return super().__iter__()  # type: ignore
 
     @property
     def data(self) -> Sequence[Data]:
@@ -67,7 +87,7 @@ class Register(cyRegister, AbstractSet[Data], Sequence[Data]):
         """Returns the representation of the Register object."""
         return f"<{self.__class__.__name__}, data={list(self)}>"
 
-    def __add__(self, qreg: Register):
+    def __add__(self, qreg: Register) -> Self:
         """Adds two registers together and returns a register referencing the contained items.
 
         Args:

--- a/examples/0_circuit.py
+++ b/examples/0_circuit.py
@@ -43,11 +43,20 @@ print("Qubits:", circuit.qubits)
 
 # To create a circuit, we use the circuit context manager and append gates as follows;
 # an X-gate to the first qubit (q[0]) and an X-rotation to the second qubit (q[1]).
-with circuit.context as q:
+with circuit.context as (q, c):
     X(q[0])
     RX(0.5, q[1])
 
 print("Circuit", circuit.circuit)
+
+# Note that 'circuit.context' returns a NamedTuple which is unpacked dirctly into 'c' and 'q' above.
+# It would work equally well to simply keep the named tuple as e.g., 'reg' and then call the quantum
+# and classical registers via 'reg.q' and 'reg.c' respectively:
+#
+#   with circuit.context as reg:
+#       X(reg.q[0])
+#       RX(0.5, reg.q[1])
+#
 
 # We now have a circuit object which we could, for example, send to run on a compatible
 # simulator or hardware. After the circuit has been created it is automatically locked.
@@ -56,7 +65,7 @@ print("Circuit", circuit.circuit)
 circuit.unlock()
 
 # We can now apply more gates which will be appended to the circuit.
-with circuit.context as q:
+with circuit.context as (q, c):
     CNOT(q[0], q[1])
 
 print("Circuit", circuit.circuit)

--- a/examples/1_operations.py
+++ b/examples/1_operations.py
@@ -33,7 +33,7 @@ print("Z-rotation matrix:\n", ops.RZ(4.2).matrix)
 # parameters can be passed either as single values (if supported by the gate) or contained in a
 # sequence.
 circuit = Circuit(3)
-with circuit.context as q:
+with circuit.context as (q, c):
     # apply single-qubit gate
     ops.Z(q[0])
     # apply single-qubit gate using kwarg

--- a/examples/2_templates.py
+++ b/examples/2_templates.py
@@ -23,7 +23,7 @@ np.set_printoptions(suppress=True)
 # Let's create a circuit which applies a Z-gate to a single qubit, but by using
 # only Hadamards and X-gates.
 z_circuit = Circuit(1)
-with z_circuit.context as q:
+with z_circuit.context as (q, c):
     ops.Hadamard(q[0])
     ops.X(q[0])
     ops.Hadamard(q[0])
@@ -37,7 +37,7 @@ print("Z matrix:\n", z_matrix)
 # The above circuit can also be applied to other circuits. This will basically just apply the
 # operations within that circuit to the new circuit, mapping the old qubits to the new.
 circuit = Circuit(3)
-with circuit.context as q:
+with circuit.context as (q, c):
     z_circuit(q[1])
 
 print("Circuit:", circuit.circuit)
@@ -60,7 +60,7 @@ assert np.allclose(MyZOperation.matrix, ops.Z.matrix)
 # This custom gate can now be applied to the circuit in exactly the same way as any other gate. Note
 # that if we don't reset the circuit, the 'z_circuit' operations will still be there.
 circuit.reset()
-with circuit.context as q:
+with circuit.context as (q, c):
     MyZOperation(q[2])
 
 print("Circuit:", circuit.circuit)

--- a/examples/3_parametric_circuits.py
+++ b/examples/3_parametric_circuits.py
@@ -22,7 +22,7 @@ np.set_printoptions(suppress=True)
 
 # Let's create a parametric circuit which applies a rotation gate to a single qubit
 rot_circuit = ParametricCircuit(1)
-with rot_circuit.context as (p, q):
+with rot_circuit.context as (p, q, c):
     ops.RZ(p[0], q[0])
     ops.RY(p[1], q[0])
     ops.RZ(p[2], q[0])
@@ -32,7 +32,7 @@ with rot_circuit.context as (p, q):
 # parametric circuit, the parameters need to be passed when calling it, similarly to how parametric
 # operations work.
 circuit = Circuit(3)
-with circuit.context as q:
+with circuit.context as (q, c):
     rot_circuit([np.pi, np.pi / 2, np.pi], q[1])
 
 print("Circuit:", circuit.circuit)
@@ -56,7 +56,7 @@ assert np.allclose(MyRotOperation(params).matrix, ops.Rotation(params).matrix)
 # This custom gate can now be applied to the circuit in exactly the same way as any other gate. Note
 # that if we don't reset the circuit, the 'rot_circuit' operations will still be there.
 circuit.reset()
-with circuit.context as q:
+with circuit.context as (q, c):
     MyRotOperation([3 * np.pi / 2, np.pi / 2, np.pi], q[2])
 
 print("Circuit:", circuit.circuit)

--- a/releasenotes/notes/context-returns-namedtuple-83bda2334a7fb8d1.yaml
+++ b/releasenotes/notes/context-returns-namedtuple-83bda2334a7fb8d1.yaml
@@ -1,0 +1,30 @@
+---
+features:
+  - |
+    Circuit context returns the classical register together with ``QuantumRegister``. The two
+    registers are contained within a tuple and are returned as ``with circuit.context as (q, c)``,
+    instead of ``with circuit.context as q``.
+
+    .. code-block:: python
+
+      circuit = Circuit(2, 2)
+
+      with circuit.context as (q, c):
+          ops.X(q[0])
+
+upgrade:
+  - |
+    Update context to return a ``NamedTuple`` instead of a regular tuple, allowing for the registers
+    to be returned as previously, directly unpacked into ``q`` and ``c``, or as a named ``Registers``
+    tuple and retrieved via ``Registers.q`` and ``Registers.c`` respectively.
+  - |
+    Update parametric context to return a ``NamedTuple`` instead of a regular tuple similar to the
+    non-parametric context upgrade, with the parameter register accessed via ``Registers.p``.
+
+    .. code-block:: python
+
+      circuit = ParametricCircuit(2, 2)
+
+      with circuit.context as reg:
+          ops.RX(reg.p[0], reg.q[0])
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@ pytest==7.2.0
 pytest-cov==4.0.0
 pytest-mock==3.10.0
 reno==3.5.0
+typing_extensions==4.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,10 @@ def two_qubit_circuit():
     """Circuit with two qubits and three operations."""
     circuit = Circuit(2)
 
-    with circuit.context as q:
-        ops.Hadamard(q[0])
-        ops.CNOT(q[0], q[1])
-        ops.Hadamard(q[1])
+    with circuit.context as regs:
+        ops.Hadamard(regs.q[0])
+        ops.CNOT(regs.q[0], regs.q[1])
+        ops.Hadamard(regs.q[1])
 
     return circuit
 
@@ -39,9 +39,9 @@ def two_qubit_parametric_circuit():
     """ParametricCircuit with two qubits and two operation."""
     circuit = ParametricCircuit(2)
 
-    with circuit.context as (p, q):
-        ops.RX(p[0], q[0])
-        ops.RY(p[1], q[1])
+    with circuit.context as regs:
+        ops.RX(regs.p[0], regs.q[0])
+        ops.RY(regs.p[1], regs.q[1])
 
     return circuit
 
@@ -50,8 +50,8 @@ def two_qubit_parametric_circuit():
 def two_bit_circuit():
     """Circuit with two bits and one qubit and a single operation."""
     circuit = Circuit(1, 2)
-    with circuit.context as q:
-        ops.X(q[0])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
 
     return circuit
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -396,8 +396,8 @@ class TestCircuit:
         circuit_1.extend(operations)
 
         circuit_2 = Circuit(3)
-        with circuit_2.context as q:
-            circuit_1((q[0], q[2]))
+        with circuit_2.context as regs:
+            circuit_1((regs.q[0], regs.q[2]))
 
         assert circuit_2.circuit == [
             ops.X(circuit_2.qubits[0]),
@@ -419,8 +419,8 @@ class TestCircuit:
         circuit_1.extend(operations)
 
         circuit_2 = Circuit(3)
-        with circuit_2.context as q:
-            circuit_1(qubits=(q[0], q[2]))
+        with circuit_2.context as regs:
+            circuit_1(qubits=(regs.q[0], regs.q[2]))
 
         assert circuit_2.circuit == [
             ops.X(circuit_2.qubits[0]),
@@ -437,8 +437,8 @@ class TestCircuit:
         circuit_1.extend(operations)
 
         circuit_2 = Circuit(2)
-        with circuit_2.context as q:
-            circuit_1(q[1])
+        with circuit_2.context as regs:
+            circuit_1(regs.q[1])
 
         assert circuit_2.circuit == [ops.X(circuit_2.qubits[1]), ops.RY(0.42, circuit_2.qubits[1])]
 
@@ -450,8 +450,8 @@ class TestCircuit:
 
         circuit_2 = Circuit(2)
         with pytest.raises(ValueError, match="requires 2 qubits, got 1"):
-            with circuit_2.context as q:
-                circuit_1(q[1])
+            with circuit_2.context as regs:
+                circuit_1(regs.q[1])
 
     def test_calling_in_own_context(self):
         """Test that the correct exception is raised when calling a circuit inside it's own context."""
@@ -460,8 +460,8 @@ class TestCircuit:
         circuit_1.extend(operations)
 
         with pytest.raises(TypeError, match="Cannot apply circuit in its own context."):
-            with circuit_1.context as q:
-                circuit_1(q[0])
+            with circuit_1.context as regs:
+                circuit_1(regs.q[0])
 
     def test_call_outside_context(self):
         """Test that the correct exception is raised when calling a circuit outside of a context."""
@@ -585,13 +585,13 @@ class TestParametricCircuit:
         parametric_circuit = ParametricCircuit(1)
         circuit = Circuit(2)
 
-        with parametric_circuit.context as (p, q):
-            ops.X(q[0])
-            ops.RY(p[0], q[0])
-            ops.RZ(3.3, q[0])
+        with parametric_circuit.context as regs:
+            ops.X(regs.q[0])
+            ops.RY(regs.p[0], regs.q[0])
+            ops.RZ(3.3, regs.q[0])
 
-        with circuit.context as q:
-            parametric_circuit([4.2], q[1])
+        with circuit.context as regs:
+            parametric_circuit([4.2], regs.q[1])
 
         assert circuit.circuit == [
             ops.X(circuit.qubits[1]),
@@ -606,10 +606,10 @@ class TestParametricCircuit:
         assert parametric_circuit.parametric is False
         assert parametric_circuit.num_parameters == 0
 
-        with parametric_circuit.context as (p, q):
-            ops.X(q[0])
-            ops.RY(p[0], q[0])
-            ops.RZ(p[1], q[0])
+        with parametric_circuit.context as regs:
+            ops.X(regs.q[0])
+            ops.RY(regs.p[0], regs.q[0])
+            ops.RZ(regs.p[1], regs.q[0])
 
         assert parametric_circuit.parametric is True
         assert parametric_circuit.num_parameters == 2
@@ -618,15 +618,15 @@ class TestParametricCircuit:
         """Test accessing a cached context by calling it twice."""
         parametric_circuit = ParametricCircuit(1)
 
-        with parametric_circuit.context as (p, q):
-            ops.RY(p[0], q[0])
+        with parametric_circuit.context as regs:
+            ops.RY(regs.p[0], regs.q[0])
 
         assert parametric_circuit.parametric is True
         assert parametric_circuit.num_parameters == 1
 
         parametric_circuit.unlock()
-        with parametric_circuit.context as (p, q):
-            ops.RZ(p[1], q[0])
+        with parametric_circuit.context as regs:
+            ops.RZ(regs.p[1], regs.q[0])
 
         assert parametric_circuit.parametric is True
         assert parametric_circuit.num_parameters == 2
@@ -634,8 +634,8 @@ class TestParametricCircuit:
     def test_eval(self, empty_parametric_circuit):
         """Test evaluate circuit with parameters."""
         empty_parametric_circuit.add_qubit()
-        with empty_parametric_circuit.context as (p, q):
-            ops.RX(p[0], q[0])
+        with empty_parametric_circuit.context as regs:
+            ops.RX(regs.p[0], regs.q[0])
 
         for op in empty_parametric_circuit.circuit:
             for p in op.parameters:
@@ -652,8 +652,8 @@ class TestParametricCircuit:
     def test_eval_in_place(self, empty_parametric_circuit):
         """Test evaluate circuit in place with parameters."""
         empty_parametric_circuit.add_qubit()
-        with empty_parametric_circuit.context as (p, q):
-            ops.RX(p[0], q[0])
+        with empty_parametric_circuit.context as regs:
+            ops.RX(regs.p[0], regs.q[0])
 
         for op in empty_parametric_circuit.circuit:
             for p in op.parameters:
@@ -667,8 +667,8 @@ class TestParametricCircuit:
     def test_eval_no_params(self, empty_parametric_circuit):
         """Test that the correct exception is raised when evaluating circuit without parameters."""
         empty_parametric_circuit.add_qubit()
-        with empty_parametric_circuit.context as (p, q):
-            ops.RX(p[0], q[0])
+        with empty_parametric_circuit.context as regs:
+            ops.RX(regs.p[0], regs.q[0])
 
         for op in empty_parametric_circuit.circuit:
             for p in op.parameters:
@@ -680,8 +680,8 @@ class TestParametricCircuit:
     def test_call_outside_context(self):
         """Test that the correct exception is raised when calling a circuit outside of a context."""
         circuit_1 = ParametricCircuit(1)
-        with circuit_1.context as (p, q):
-            ops.RX(p[0], q[0])
+        with circuit_1.context as regs:
+            ops.RX(regs.p[0], regs.q[0])
 
         with pytest.raises(
             CircuitError, match="Can only apply circuit object inside a circuit context."

--- a/tests/test_io/test_openqasm.py
+++ b/tests/test_io/test_openqasm.py
@@ -31,10 +31,10 @@ class TestCircuitOpenQASM:
         circuit = Circuit(3)
         circuit.add_cregister(2, "apple")
 
-        with circuit.context as q:
-            ops.X(q[0])
-            ops.RX(0.42, q[1])
-            ops.CNOT(q[2], q[0])
+        with circuit.context as regs:
+            ops.X(regs.q[0])
+            ops.RX(0.42, regs.q[1])
+            ops.CNOT(regs.q[2], regs.q[0])
 
         assert circuit.to_qasm() == cleandoc(
             """
@@ -55,10 +55,10 @@ class TestCircuitOpenQASM:
         circuit = Circuit(1)
         circuit.add_qregister(2, "apple")
 
-        with circuit.context as q:
-            ops.X(q[0])
-            ops.RX(0.42, q[1])
-            ops.CNOT(q[2], q[0])
+        with circuit.context as regs:
+            ops.X(regs.q[0])
+            ops.RX(0.42, regs.q[1])
+            ops.CNOT(regs.q[2], regs.q[0])
 
         assert circuit.to_qasm() == cleandoc(
             """
@@ -80,10 +80,10 @@ class TestCircuitOpenQASM:
         circuit.add_cregister(2, "apple")
         circuit.add_cregister(3, "banana")
 
-        with circuit.context as q:
-            ops.X(q[0])
-            ops.RX(0.42, q[1])
-            ops.CNOT(q[1], q[0])
+        with circuit.context as regs:
+            ops.X(regs.q[0])
+            ops.RX(0.42, regs.q[1])
+            ops.CNOT(regs.q[1], regs.q[0])
 
         assert circuit.to_qasm() == cleandoc(
             """
@@ -106,10 +106,10 @@ class TestCircuitOpenQASM:
         circuit.add_qregister(2, "apple")
         circuit.add_cregister(2, "banana")
 
-        with circuit.context as q:
-            ops.X(q[0])
-            ops.RX(0.42, q[1])
-            ops.CNOT(q[2], q[0])
+        with circuit.context as regs:
+            ops.X(regs.q[0])
+            ops.RX(0.42, regs.q[1])
+            ops.CNOT(regs.q[2], regs.q[0])
 
         assert circuit.to_qasm(reg_labels=True) == cleandoc(
             """
@@ -130,10 +130,10 @@ class TestCircuitOpenQASM:
         """Test generating OpenQASM 2.0 for a circuit using gate definitions."""
         circuit = Circuit(3)
 
-        with circuit.context as q:
-            ops.X(q[0])
-            ops.Rotation((0.1, 0.2, 0.3), q[1])
-            ops.CNOT(q[2], q[0])
+        with circuit.context as regs:
+            ops.X(regs.q[0])
+            ops.Rotation((0.1, 0.2, 0.3), regs.q[1])
+            ops.CNOT(regs.q[2], regs.q[0])
 
         assert circuit.to_qasm(gate_definitions=True) == cleandoc(
             """
@@ -155,10 +155,10 @@ class TestCircuitOpenQASM:
 
         circuit = ParametricCircuit(3)
 
-        with circuit.context as (p, q):
-            ops.X(q[0])
-            ops.RX(p[0], q[1])
-            ops.CNOT(q[2], q[0])
+        with circuit.context as regs:
+            ops.X(regs.q[0])
+            ops.RX(regs.p[0], regs.q[1])
+            ops.CNOT(regs.q[2], regs.q[0])
 
         with pytest.raises(
             CircuitError, match="Parametric circuits cannot be transpiled into OpenQASM."
@@ -237,10 +237,10 @@ class TestOperationsOpenQASM:
         """Test creating an operation."""
         circuit = Circuit(1)
 
-        with circuit.context as q:
-            ops.Hadamard(q[0])
-            ops.X(q[0])
-            ops.Hadamard(q[0])
+        with circuit.context as regs:
+            ops.Hadamard(regs.q[0])
+            ops.X(regs.q[0])
+            ops.Hadamard(regs.q[0])
 
         ZOp = create_operation(circuit, name="ZOp")
 
@@ -251,10 +251,10 @@ class TestOperationsOpenQASM:
         """Test creating an operation without a label."""
         circuit = Circuit(1)
 
-        with circuit.context as q:
-            ops.Hadamard(q[0])
-            ops.X(q[0])
-            ops.Hadamard(q[0])
+        with circuit.context as regs:
+            ops.Hadamard(regs.q[0])
+            ops.X(regs.q[0])
+            ops.Hadamard(regs.q[0])
 
         ZOp = create_operation(circuit)
 

--- a/tests/test_operations/test_base.py
+++ b/tests/test_operations/test_base.py
@@ -190,8 +190,8 @@ class TestMatrixRepr:
     def test_controlled_matrix_repr(self, op, qubits, matrix, two_qubit_circuit):
         """Test that controlled matrix representations are correct."""
         two_qubit_circuit.unlock()
-        with two_qubit_circuit.context as q:
-            assert np.allclose(op(*[q[i] for i in qubits]).matrix, matrix)
+        with two_qubit_circuit.context as regs:
+            assert np.allclose(op(*[regs.q[i] for i in qubits]).matrix, matrix)
 
 
 @pytest.mark.xfail(reason="Measurements are not implemented yet.")
@@ -211,10 +211,10 @@ class TestCreateOperation:
         """Test creating an operation out of a parametric circuit."""
         circuit = ParametricCircuit(1)
 
-        with circuit.context as (p, q):
-            ops.RZ(p[0], q[0])
-            ops.RY(p[1], q[0])
-            ops.RZ(p[2], q[0])
+        with circuit.context as regs:
+            ops.RZ(regs.p[0], regs.q[0])
+            ops.RY(regs.p[1], regs.q[0])
+            ops.RZ(regs.p[2], regs.q[0])
 
         RotOp = create_operation(circuit, name="Rot")
         params = [0.23, 0.34, 0.45]
@@ -230,10 +230,10 @@ class TestCreateOperation:
         """Test creating an operation out of a non-parametric circuit."""
         circuit = Circuit(1)
 
-        with circuit.context as q:
-            ops.Hadamard(q[0])
-            ops.X(q[0])
-            ops.Hadamard(q[0])
+        with circuit.context as regs:
+            ops.Hadamard(regs.q[0])
+            ops.X(regs.q[0])
+            ops.Hadamard(regs.q[0])
 
         ZOp = create_operation(circuit, name="Z")
 
@@ -244,10 +244,10 @@ class TestCreateOperation:
         """Test creating an operation without a label."""
         circuit = Circuit(1)
 
-        with circuit.context as q:
-            ops.Hadamard(q[0])
-            ops.X(q[0])
-            ops.Hadamard(q[0])
+        with circuit.context as regs:
+            ops.Hadamard(regs.q[0])
+            ops.X(regs.q[0])
+            ops.Hadamard(regs.q[0])
 
         ZOp = create_operation(circuit)
 
@@ -258,12 +258,12 @@ class TestCreateOperation:
         parameters."""
         circuit = ParametricCircuit(1)
 
-        with circuit.context as (p, q):
-            ops.RZ(0.1, q[0])
-            ops.RY(p[0], q[0])
-            ops.RZ(0.3, q[0])
-            ops.X(q[0])  # cover testing non-parametric ops in parametric circuits
-            ops.X(q[0])  # negate the previous X-gate to compare with Rotation-gate
+        with circuit.context as regs:
+            ops.RZ(0.1, regs.q[0])
+            ops.RY(regs.p[0], regs.q[0])
+            ops.RZ(0.3, regs.q[0])
+            ops.X(regs.q[0])  # cover testing non-parametric ops in parametric circuits
+            ops.X(regs.q[0])  # negate the previous X-gate to compare with Rotation-gate
 
         RotOp = create_operation(circuit, name="Rot")
         params = [0.2]

--- a/tests/test_operations/test_operations.py
+++ b/tests/test_operations/test_operations.py
@@ -81,10 +81,10 @@ def z_op() -> Type[Operation]:
     """
     circuit = Circuit(1)
 
-    with circuit.context as q:
-        ops.Hadamard(q[0])
-        ops.X(q[0])
-        ops.Hadamard(q[0])
+    with circuit.context as regs:
+        ops.Hadamard(regs.q[0])
+        ops.X(regs.q[0])
+        ops.Hadamard(regs.q[0])
 
     return create_operation(circuit, name="CustomZ")
 
@@ -98,10 +98,10 @@ def rot_op() -> Type[Operation]:
     """
     circuit = ParametricCircuit(1)
 
-    with circuit.context as (p, q):
-        ops.RZ(p[0], q[0])
-        ops.RY(p[1], q[0])
-        ops.RZ(p[2], q[0])
+    with circuit.context as regs:
+        ops.RZ(regs.p[0], regs.q[0])
+        ops.RY(regs.p[1], regs.q[0])
+        ops.RZ(regs.p[2], regs.q[0])
 
     return create_operation(circuit, name="CustomRot")
 
@@ -238,8 +238,8 @@ class TestParametricOperations:
         params = list(range(ParamOp.num_parameters))
 
         empty_circuit.add_qregister(ParamOp.num_qubits)
-        with empty_circuit.context as q:
-            op = ParamOp(params, q)
+        with empty_circuit.context as regs:
+            op = ParamOp(params, regs.q)
 
         assert empty_circuit.circuit == [op]
 
@@ -262,8 +262,8 @@ class TestParametricOperations:
         with pytest.raises(
             ValueError, match=f"requires {ParamOp.num_qubits} qubits, got {ParamOp.num_qubits + 9}."
         ):
-            with empty_circuit.context as q:
-                ParamOp(params, q)
+            with empty_circuit.context as regs:
+                ParamOp(params, regs.q)
 
     def test_applying_operation_instance(self, empty_circuit, ParamOp):
         """Test applying an instance of a parametric operation within a context."""
@@ -417,8 +417,10 @@ class TestControlledOperations:
     def test_initializing_gate_in_context(self, empty_circuit, ControlledOp):
         """Test initializing a controlled operation within a context."""
         empty_circuit.add_qregister(ControlledOp.num_qubits)
-        with empty_circuit.context as q:
-            op = ControlledOp(q[: ControlledOp.num_control], q[ControlledOp.num_control :])
+        with empty_circuit.context as regs:
+            op = ControlledOp(
+                regs.q[: ControlledOp.num_control], regs.q[ControlledOp.num_control :]
+            )
 
         assert empty_circuit.circuit == [op]
 
@@ -438,8 +440,8 @@ class TestControlledOperations:
             ValueError,
             match=f"requires {ControlledOp.num_qubits} qubits, got {ControlledOp.num_qubits + 9}.",
         ):
-            with empty_circuit.context as q:
-                ControlledOp(q[: ControlledOp.num_control], q[ControlledOp.num_control :])
+            with empty_circuit.context as regs:
+                ControlledOp(regs.q[: ControlledOp.num_control], regs.q[ControlledOp.num_control :])
 
     def test_applying_operation_instance(self, empty_circuit, ControlledOp):
         """Test applying an instance of a controlled operation within a context."""
@@ -491,11 +493,11 @@ class TestParametricControlledOperations:
         params = [f"p{i}" for i in range(ParametricControlledOp.num_parameters)]
 
         empty_circuit.add_qregister(ParametricControlledOp.num_qubits)
-        with empty_circuit.context as q:
+        with empty_circuit.context as regs:
             op = ParametricControlledOp(
                 params,
-                q[: ParametricControlledOp.num_control],
-                q[ParametricControlledOp.num_control :],
+                regs.q[: ParametricControlledOp.num_control],
+                regs.q[ParametricControlledOp.num_control :],
             )
 
         assert empty_circuit.circuit == [op]
@@ -522,11 +524,11 @@ class TestParametricControlledOperations:
             ValueError,
             match=f"requires {ParametricControlledOp.num_qubits} qubits, got {ParametricControlledOp.num_qubits + 9}.",
         ):
-            with empty_circuit.context as q:
+            with empty_circuit.context as regs:
                 ParametricControlledOp(
                     params,
-                    q[: ParametricControlledOp.num_control],
-                    q[ParametricControlledOp.num_control :],
+                    regs.q[: ParametricControlledOp.num_control],
+                    regs.q[ParametricControlledOp.num_control :],
                 )
 
     def test_applying_operation_instance(self, empty_circuit, ParametricControlledOp):
@@ -578,8 +580,8 @@ class TestOtherOperations:
     def test_initializing_gate_in_context(self, empty_circuit, Op):
         """Test initializing an operation within a context."""
         empty_circuit.add_qregister(Op.num_qubits)
-        with empty_circuit.context as q:
-            op = Op(q)
+        with empty_circuit.context as regs:
+            op = Op(regs.q)
 
         assert empty_circuit.circuit == [op]
 
@@ -598,8 +600,8 @@ class TestOtherOperations:
         with pytest.raises(
             ValueError, match=f"requires {Op.num_qubits} qubits, got {Op.num_qubits + 9}."
         ):
-            with empty_circuit.context as q:
-                Op(q)
+            with empty_circuit.context as regs:
+                Op(regs.q)
 
     def test_applying_operation_instance(self, empty_circuit, Op):
         """Test applying an instance of an operation within a context."""

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -12,12 +12,12 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import pytest
 import numpy as np
+import pytest
 
 import dwave.gate.operations as ops
-from dwave.gate.operations.operations import __all__ as all_ops
 from dwave.gate.circuit import Circuit
+from dwave.gate.operations.operations import __all__ as all_ops
 from dwave.gate.simulator.simulator import simulate
 
 
@@ -59,25 +59,25 @@ def test_simulate_dm_no_ops_two_qubit():
 
 def test_simulate_sv_not():
     circuit = Circuit(1)
-    with circuit.context as q:
-        ops.X(q[0])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
     state = simulate(circuit)
     assert np.all(state == np.array([0, 1]))
 
 
 def test_simulate_dm_not():
     circuit = Circuit(1)
-    with circuit.context as q:
-        ops.X(q[0])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
     state = simulate(circuit, mixed_state=True)
     assert np.all(state == np.array([[0, 0], [0, 1]]))
 
 
 def test_simulate_sv_cnot():
     circuit = Circuit(2)
-    with circuit.context as q:
-        ops.X(q[0])
-        ops.CNOT(q[0], q[1])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
+        ops.CNOT(regs.q[0], regs.q[1])
     state = simulate(circuit)
     # should be |11>
     assert np.all(state == np.array([0, 0, 0, 1]))
@@ -85,9 +85,9 @@ def test_simulate_sv_cnot():
 
 def test_simulate_dm_cnot():
     circuit = Circuit(2)
-    with circuit.context as q:
-        ops.X(q[0])
-        ops.CNOT(q[0], q[1])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
+        ops.CNOT(regs.q[0], regs.q[1])
     state = simulate(circuit, mixed_state=True)
     # should be |11>
     pure_11 = np.zeros((4, 4))
@@ -97,8 +97,8 @@ def test_simulate_dm_cnot():
 
 def test_simulate_sv_big_endian():
     circuit = Circuit(2)
-    with circuit.context as q:
-        ops.X(q[1])
+    with circuit.context as regs:
+        ops.X(regs.q[1])
 
     state = simulate(circuit, little_endian=False)
     assert np.all(state == np.array([0, 1, 0, 0]))
@@ -106,8 +106,8 @@ def test_simulate_sv_big_endian():
 
 def test_simulate_sv_little_endian():
     circuit = Circuit(2)
-    with circuit.context as q:
-        ops.X(q[1])
+    with circuit.context as regs:
+        ops.X(regs.q[1])
 
     state = simulate(circuit, little_endian=True)
     assert np.all(state == np.array([0, 0, 1, 0]))
@@ -115,11 +115,11 @@ def test_simulate_sv_little_endian():
 
 def test_simulate_sv_swap():
     circuit = Circuit(2)
-    with circuit.context as q:
-        ops.X(q[0])
-        ops.Hadamard(q[0])
-        ops.Hadamard(q[1])
-        ops.SWAP([q[0], q[1]])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
+        ops.Hadamard(regs.q[0])
+        ops.Hadamard(regs.q[1])
+        ops.SWAP([regs.q[0], regs.q[1]])
 
     state = simulate(circuit, little_endian=False)
 
@@ -128,11 +128,11 @@ def test_simulate_sv_swap():
 
 def test_simulate_dm_swap():
     circuit = Circuit(2)
-    with circuit.context as q:
-        ops.X(q[0])
-        ops.Hadamard(q[0])
-        ops.Hadamard(q[1])
-        ops.SWAP([q[0], q[1]])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
+        ops.Hadamard(regs.q[0])
+        ops.Hadamard(regs.q[1])
+        ops.SWAP([regs.q[0], regs.q[1]])
 
     state = simulate(circuit, little_endian=False)
 
@@ -141,10 +141,10 @@ def test_simulate_dm_swap():
 
 def test_simulate_sv_ccx():
     circuit = Circuit(3)
-    with circuit.context as q:
-        ops.X(q[0])
-        ops.X(q[2])
-        ops.CCX([q[0], q[2], q[1]])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
+        ops.X(regs.q[2])
+        ops.CCX([regs.q[0], regs.q[2], regs.q[1]])
 
     state = simulate(circuit)
 
@@ -154,10 +154,10 @@ def test_simulate_sv_ccx():
 
 def test_simulate_dm_ccx():
     circuit = Circuit(3)
-    with circuit.context as q:
-        ops.X(q[0])
-        ops.X(q[2])
-        ops.CCX([q[0], q[2], q[1]])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
+        ops.X(regs.q[2])
+        ops.CCX([regs.q[0], regs.q[2], regs.q[1]])
 
     state = simulate(circuit, mixed_state=True)
 
@@ -170,10 +170,10 @@ def test_simulate_dm_ccx():
 
 def test_simulate_sv_cswap():
     circuit = Circuit(3)
-    with circuit.context as q:
-        ops.X(q[0])
-        ops.X(q[1])
-        ops.CSWAP([q[1], q[0], q[2]])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
+        ops.X(regs.q[1])
+        ops.CSWAP([regs.q[1], regs.q[0], regs.q[2]])
 
     state = simulate(circuit, little_endian=False)
 
@@ -183,10 +183,10 @@ def test_simulate_sv_cswap():
 
 def test_simulate_dm_cswap():
     circuit = Circuit(3)
-    with circuit.context as q:
-        ops.X(q[0])
-        ops.X(q[1])
-        ops.CSWAP([q[1], q[0], q[2]])
+    with circuit.context as regs:
+        ops.X(regs.q[0])
+        ops.X(regs.q[1])
+        ops.CSWAP([regs.q[1], regs.q[0], regs.q[2]])
 
     state = simulate(circuit, little_endian=False, mixed_state=True)
 
@@ -203,11 +203,11 @@ def test_simulate_dm_cswap():
 def test_simulate_all_gates(op, little_endian, mixed_state):
     circuit = Circuit(op.num_qubits)
     kwargs = {}
-    with circuit.context as q:
+    with circuit.context as regs:
         if issubclass(op, ops.ParametricOperation):
             # TODO random parameters?
             kwargs["parameters"] = [0 for i in range(op.num_parameters)]
-        kwargs["qubits"] = [q[i] for i in range(op.num_qubits)]
+        kwargs["qubits"] = [regs.q[i] for i in range(op.num_qubits)]
 
         op(**kwargs)
 


### PR DESCRIPTION
Updates the context manager so that it returns a `NamedTuple` instead of a regular tuple. This allows for easy access to the registers without having to always unpack the tuple on context enter.

```python
with circuit.context as reg:
    X(reg.q[0])
    RX(0.5, reg.q[1])
```

works as well as

```python
with circuit.context as (q, c):
    X(q[0])
    RX(0.5, q[1])
```