### PR TITLE
Fix various issues

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ branch = True
 plugins = Cython.Coverage
 omit =
     dwave/gate/simulator/ops.pxd
+    dwave/gate/simulator/operation_generation.py
 
 [report]
 exclude_lines =

--- a/dwave/gate/circuit.py
+++ b/dwave/gate/circuit.py
@@ -20,6 +20,7 @@ operations and instructions for running the circuits on simulators or hardware. 
 """
 
 from __future__ import annotations
+
 import itertools
 
 __all__ = [
@@ -396,7 +397,9 @@ class Circuit:
         qb, cb = len(self.qubits), len(self.bits)
         return f"<{self.__class__.__name__}: qubits={qb}, bits={cb}, ops={len(self.circuit)}>"
 
-    def get_qubit(self, label: str, qreg_label: Optional[str] = None, return_all: bool = False) -> Qubits:
+    def get_qubit(
+        self, label: str, qreg_label: Optional[str] = None, return_all: bool = False
+    ) -> Qubits:
         """Returns the Qubit(s) with a specific label.
 
         Args:
@@ -450,7 +453,9 @@ class Circuit:
 
         raise ValueError(f"Qubit {qubit} not found in any register.")
 
-    def get_bit(self, label: str, creg_label: Optional[str] = None, return_all: bool = False) -> Bits:
+    def get_bit(
+        self, label: str, creg_label: Optional[str] = None, return_all: bool = False
+    ) -> Bits:
         """Returns the Bit(s) with a specific label.
 
         Args:

--- a/dwave/gate/circuit.py
+++ b/dwave/gate/circuit.py
@@ -363,7 +363,7 @@ class Circuit:
         if label in self._qregisters:
             raise ValueError(f"Quantum register {label} already present in the circuit.")
 
-        data = [Qubit(str(i)) for i in range(self.num_qubits, self.num_qubits + num_qubits)]
+        data = (Qubit(str(i)) for i in range(self.num_qubits, self.num_qubits + num_qubits))
         self._qregisters[label] = QuantumRegister(data)
 
         # remove cached 'qubits' attribute when updating 'qregisters'
@@ -384,7 +384,7 @@ class Circuit:
         if label in self._cregisters:
             raise ValueError(f"Classical register {label} already present in the circuit")
 
-        data = [Bit(str(i)) for i in range(self.num_bits, self.num_bits + num_bits)]
+        data = (Bit(str(i)) for i in range(self.num_bits, self.num_bits + num_bits))
         self._cregisters[label] = ClassicalRegister(data)
 
         # remove cached 'bits' attribute when updating 'cregisters'

--- a/dwave/gate/mixedproperty.py
+++ b/dwave/gate/mixedproperty.py
@@ -94,12 +94,7 @@ class mixedproperty:
         # don't patch '__qualname__' due to Sphinx calling the mixedproperty
         # at docsbuild, raising exceptions and thus not rendering all entries
         for attr in ("__module__", "__name__", "__doc__", "__annotations__"):
-            try:
-                value = getattr(callable_, attr)
-            except (AttributeError, NotImplementedError):
-                pass
-            else:
-                setattr(self, attr, value)
+            self.attr = getattr(callable_, attr)
         getattr(self, "__dict__").update(getattr(callable_, "__dict__", {}))
 
         self.__wrapped__ = callable_

--- a/dwave/gate/operations/base.py
+++ b/dwave/gate/operations/base.py
@@ -220,7 +220,7 @@ class Operation(metaclass=ABCLockedAttr):
 
         if cls._num_qubits is not None and len(qubits) != cls.num_qubits:
             raise ValueError(
-                f"Operation '{cls.label}' requires " f"{cls.num_qubits} qubits, got {len(qubits)}."
+                f"Operation '{cls.name}' requires " f"{cls.num_qubits} qubits, got {len(qubits)}."
             )
 
         # cast to tuple for convention
@@ -265,12 +265,12 @@ class Operation(metaclass=ABCLockedAttr):
     def __repr__(self) -> str:
         """Returns the representation of the Operation object."""
         if self._cond:
-            return f"<{self.__class__.__base__.__name__}: {self.label}, qubits={self.qubits}, conditional: {self._cond}>"
-        return f"<{self.__class__.__base__.__name__}: {self.label}, qubits={self.qubits}>"
+            return f"<{self.__class__.__base__.__name__}: {self.name}, qubits={self.qubits}, conditional: {self._cond}>"
+        return f"<{self.__class__.__base__.__name__}: {self.name}, qubits={self.qubits}>"
 
     @mixedproperty
-    def label(cls, self) -> str:
-        """Qubit operation label."""
+    def name(cls, self) -> str:
+        """Qubit operation name."""
         if self and hasattr(self, "parameters"):
             params = f"({self.parameters})"
             return cls.__name__ + params  # type: ignore
@@ -282,7 +282,7 @@ class Operation(metaclass=ABCLockedAttr):
         decomposition = getattr(cls, "_decomposition", None)
         if not decomposition:
             raise NotImplementedError(
-                "Decomposition not implemented for the " f"'{cls.label}' operation."
+                "Decomposition not implemented for the " f"'{cls.name}' operation."
             )
         return decomposition
 
@@ -295,7 +295,7 @@ class Operation(metaclass=ABCLockedAttr):
         if isinstance(cls._num_qubits, int):
             return cls._num_qubits
 
-        raise AttributeError(f"Operation {cls.label} supports an arbitrary number of qubits.")
+        raise AttributeError(f"Operation {cls.name} supports an arbitrary number of qubits.")
 
     @property
     def qubits(self) -> Optional[Tuple[Qubit, ...]]:
@@ -417,7 +417,7 @@ class ParametricOperation(Operation):
         if isinstance(cls._num_params, int):
             return cls._num_params
 
-        raise AttributeError(f"Operations {cls.label} missing class attribute '_num_params'.")
+        raise AttributeError(f"Operations {cls.name} missing class attribute '_num_params'.")
 
     @classmethod
     def _check_parameters(cls, params: Parameters) -> List[Union[Variable, complex]]:
@@ -435,7 +435,7 @@ class ParametricOperation(Operation):
 
         if len(params) != cls._num_params:
             raise ValueError(
-                f"Operation '{cls.label} requires "
+                f"Operation '{cls.name} requires "
                 f"{cls._num_params} parameters, got {len(params)}."
             )
 
@@ -534,7 +534,7 @@ class ControlledOperation(Operation):
             return super(ControlledOperation, cls).num_qubits
         except AttributeError as e:
             raise AttributeError(
-                f"Operations {cls.label} missing class attributes '_num_control' and/or '_num_target'."
+                f"Operations {cls.name} missing class attributes '_num_control' and/or '_num_target'."
             ) from e
 
     @mixedproperty

--- a/dwave/gate/primitives.py
+++ b/dwave/gate/primitives.py
@@ -62,7 +62,7 @@ class Qubit:
 
     def __repr__(self) -> str:
         """The representation of the variable is its label."""
-        return f"<qubit: {self.label}, id:{self.id}>"
+        return f"<qubit: {self.label}, id: {self.id}>"
 
     def __hash__(self) -> int:
         """The hash of the qubit is determined by its id."""
@@ -112,8 +112,8 @@ class Bit:
     def __repr__(self) -> str:
         """The representation of the variable is its label."""
         if self._value is not None:
-            return f"<bit: {self.label}, id:{self.id}, value: {self.value}>"
-        return f"<bit: {self.label}, id:{self.id}>"
+            return f"<bit: {self.label}, id: {self.id}, value: {self.value}>"
+        return f"<bit: {self.label}, id: {self.id}>"
 
     def __hash__(self) -> int:
         """The hash of the qubit is determined by its id."""

--- a/dwave/gate/primitives.py
+++ b/dwave/gate/primitives.py
@@ -62,7 +62,7 @@ class Qubit:
 
     def __repr__(self) -> str:
         """The representation of the variable is its label."""
-        return f"<qubit: {self.label}, id: {self.id}>"
+        return f"<qubit: {repr(self.label)}, id: {self.id}>"
 
     def __hash__(self) -> int:
         """The hash of the qubit is determined by its id."""
@@ -112,8 +112,8 @@ class Bit:
     def __repr__(self) -> str:
         """The representation of the variable is its label."""
         if self._value is not None:
-            return f"<bit: {self.label}, id: {self.id}, value: {self.value}>"
-        return f"<bit: {self.label}, id: {self.id}>"
+            return f"<bit: {repr(self.label)}, id: {self.id}, value: {self.value}>"
+        return f"<bit: {repr(self.label)}, id: {self.id}>"
 
     def __hash__(self) -> int:
         """The hash of the qubit is determined by its id."""

--- a/dwave/gate/simulator/simulator.pyx
+++ b/dwave/gate/simulator/simulator.pyx
@@ -25,6 +25,7 @@ import warnings
 from typing import List, Optional
 
 import numpy as np
+
 cimport numpy as np
 
 import dwave.gate.operations as ops
@@ -35,8 +36,8 @@ from dwave.gate.simulator.ops cimport (
     apply_gate_control,
     apply_gate_two_control,
     apply_swap,
-    single_qubit,
     measurement_computational_basis,
+    single_qubit,
 )
 
 

--- a/releasenotes/notes/fix-open-issues-6b777eed9cf72188.yaml
+++ b/releasenotes/notes/fix-open-issues-6b777eed9cf72188.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    Check types when adding qubits/bits to a circuit and raise a ``TypeError`` if an incorrect type
+    is passed to the method.
+  - Rename ``label`` to ``name`` for operations.
+fixes:
+  - Fix inconsistent spacing in primitive object representations.
+  - Fix sequential qubit/bit labelling when adding new registers.
+  - Update operation representations to use ``repr()`` for hashables.
+

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -131,7 +131,6 @@ class TestCircuit:
         qubits = circuit.get_qubit("apple", return_all=True)
         assert qubits == [apple_qubit_0, apple_qubit_1]
 
-
     def test_find_qubit(self):
         """Test finding a qubit in a circuit."""
         circuit = Circuit()
@@ -172,6 +171,70 @@ class TestCircuit:
 
         with pytest.raises(ValueError, match="not found in any register"):
             circuit.find_qubit(Qubit("apple"), qreg_label=False)
+
+    def test_get_bit(self):
+        """Test finding and getting a bit using the label."""
+        circuit = Circuit()
+        circuit.add_cregister(2, label="fruits")
+
+        apple_bit = Bit("apple")
+        circuit.add_bit(apple_bit, "fruits")
+
+        bit = circuit.get_bit("apple")
+        assert bit == apple_bit
+
+    def test_get_bit_specific_register(self):
+        """Test finding and getting a bit in a specified register."""
+        circuit = Circuit()
+        circuit.add_cregister(2, label="fruits")
+        circuit.add_cregister(3, label="vegetables")
+
+        fruit_bit = Bit("tomato")
+        circuit.add_bit(fruit_bit, "fruits")
+        vegetable_bit = Bit("tomato")
+        circuit.add_bit(vegetable_bit, "vegetables")
+
+        bit = circuit.get_bit("tomato", creg_label="vegetables")
+        assert bit == vegetable_bit
+
+        bit = circuit.get_bit("tomato", creg_label="fruits")
+        assert bit == fruit_bit
+
+    def test_get_bit_not_found(self):
+        """Test that the correct error is raised when getting a
+        non-existing bit using the label."""
+        circuit = Circuit()
+        circuit.add_cregister(2, label="fruits")
+
+        with pytest.raises(ValueError, match="Bit 'apple' not found."):
+            bit = circuit.get_bit("apple")
+
+    def test_get_multiple_bits(self):
+        """Test finding and getting a bit when there are multiple bits
+        using the same label."""
+        circuit = Circuit()
+        circuit.add_cregister(2, label="fruits")
+
+        apple_bit_0 = Bit("apple")
+        apple_bit_1 = Bit("apple")
+        circuit.add_bit(apple_bit_0, "fruits")
+        circuit.add_bit(apple_bit_1, "fruits")
+
+        bit = circuit.get_bit("apple")
+        assert bit == apple_bit_0
+
+    def test_get_multiple_bits_return_all(self):
+        """Test finding and getting multiple bits using the same label."""
+        circuit = Circuit()
+        circuit.add_cregister(2, label="fruits")
+
+        apple_bit_0 = Bit("apple")
+        apple_bit_1 = Bit("apple")
+        circuit.add_bit(apple_bit_0, "fruits")
+        circuit.add_bit(apple_bit_1, "fruits")
+
+        bits = circuit.get_bit("apple", return_all=True)
+        assert bits == [apple_bit_0, apple_bit_1]
 
     def test_find_bit_not_found(self):
         """Test that the correct exception is raised when bit is not found."""
@@ -336,6 +399,12 @@ class TestCircuit:
         assert two_qubit_circuit.num_qubits == 4
         assert [qb.label for qb in two_qubit_circuit.qubits] == ["0", "1", "pineapple", "3"]
 
+    @pytest.mark.parametrize("not_a_qubit", ["just_a_label", 3, Bit("c0")])
+    def test_add_qubit_typerror(self, two_qubit_circuit, not_a_qubit):
+        """Test that the correct error is raised when adding the wrong type."""
+        with pytest.raises(TypeError, match="Can only add qubits to circuit."):
+            two_qubit_circuit.add_qubit(not_a_qubit)
+
     def test_add_qubit_to_empty_circuit(self, empty_circuit):
         """Test adding qubits to an empty circuit."""
         assert empty_circuit.num_qubits == 0
@@ -387,6 +456,12 @@ class TestCircuit:
 
         assert two_bit_circuit.num_bits == 4
         assert [b.label for b in two_bit_circuit.bits] == ["0", "1", "pineapple", "3"]
+
+    @pytest.mark.parametrize("not_a_bit", ["just_a_label", 3, Qubit("q0")])
+    def test_add_bit_typerror(self, two_bit_circuit, not_a_bit):
+        """Test that the correct error is raised when adding the wrong type."""
+        with pytest.raises(TypeError, match="Can only add bits to circuit."):
+            two_bit_circuit.add_bit(not_a_bit)
 
     def test_add_bit_to_empty_circuit(self, empty_circuit):
         """Test adding bits to a circuit."""

--- a/tests/test_operations/test_base.py
+++ b/tests/test_operations/test_base.py
@@ -274,10 +274,10 @@ class TestCreateOperation:
         rot_op = RotOp(params)
 
         assert RotOp.matrix is None
-        assert RotOp.label == "Rot"
+        assert RotOp.name == "Rot"
 
         assert np.allclose(rot_op.matrix, ops.Rotation(params).matrix)
-        assert rot_op.label == f"Rot({params})"
+        assert rot_op.name == f"Rot({params})"
 
     def test_non_parametric(self):
         """Test creating an operation out of a non-parametric circuit."""
@@ -291,7 +291,7 @@ class TestCreateOperation:
         ZOp = create_operation(circuit, name="Z")
 
         assert np.allclose(ZOp.matrix, ops.Z.matrix)
-        assert ZOp.label == "Z"
+        assert ZOp.name == "Z"
 
     def test_no_label(self):
         """Test creating an operation without a label."""
@@ -304,7 +304,7 @@ class TestCreateOperation:
 
         ZOp = create_operation(circuit)
 
-        assert ZOp.label == "CustomOperation"
+        assert ZOp.name == "CustomOperation"
 
     def test_parametric_mix(self):
         """Test creating an operation out of a parametric circuit with some hard-coded
@@ -323,7 +323,7 @@ class TestCreateOperation:
         rot_op = RotOp(params)
 
         assert RotOp.matrix is None
-        assert RotOp.label == "Rot"
+        assert RotOp.name == "Rot"
 
         assert np.allclose(rot_op.matrix, ops.Rotation([0.1, 0.2, 0.3]).matrix)
-        assert rot_op.label == "Rot([0.2])"
+        assert rot_op.name == "Rot([0.2])"

--- a/tests/test_operations/test_operations.py
+++ b/tests/test_operations/test_operations.py
@@ -160,9 +160,7 @@ class TestOperations:
             op = Op([0 for _ in range(Op.num_parameters)])
         else:
             op = Op()
-        assert (
-            op.__repr__() == f"<{op.__class__.__base__.__name__}: {op.name}, qubits={op.qubits}>"
-        )
+        assert op.__repr__() == f"<{op.__class__.__base__.__name__}: {op.name}, qubits={op.qubits}>"
 
     def test_repr_conditional(self, Op, classical_register):
         """Test the representation of conditional operations."""
@@ -238,7 +236,9 @@ class TestCustomOperations:
             _num_control: int = 1
             _num_target: int = 1
 
-        with pytest.raises(OperationError, match="No target operation declared for controlled operation"):
+        with pytest.raises(
+            OperationError, match="No target operation declared for controlled operation"
+        ):
             CustomOp.target_operation
 
     def test_num_parameters_attribute(self):

--- a/tests/test_operations/test_operations.py
+++ b/tests/test_operations/test_operations.py
@@ -161,7 +161,7 @@ class TestOperations:
         else:
             op = Op()
         assert (
-            op.__repr__() == f"<{op.__class__.__base__.__name__}: {op.label}, qubits={op.qubits}>"
+            op.__repr__() == f"<{op.__class__.__base__.__name__}: {op.name}, qubits={op.qubits}>"
         )
 
     def test_repr_conditional(self, Op, classical_register):
@@ -173,7 +173,7 @@ class TestOperations:
         op._cond = classical_register
         assert (
             op.__repr__()
-            == f"<{op.__class__.__base__.__name__}: {op.label}, qubits={op.qubits}, conditional: {op._cond}>"
+            == f"<{op.__class__.__base__.__name__}: {op.name}, qubits={op.qubits}, conditional: {op._cond}>"
         )
 
     def test_conditional(self, Op, classical_register):
@@ -268,14 +268,14 @@ class TestParametricOperations:
         """Test initializing a parametric operation."""
         params = list(range(ParamOp.num_parameters))
         qubits = tuple(f"q{i}" for i in range(ParamOp.num_qubits))
-        label = ParamOp.label
+        label = ParamOp.name
 
         op = ParamOp(params, qubits)
 
         assert op.parameters == params
         assert op.qubits == qubits
 
-        assert op.label == f"{label}({params})"
+        assert op.name == f"{label}({params})"
 
     def test_incorrect_number_of_params(self, ParamOp):
         """Test calling a parametric operation with the incorrect number of parameters."""
@@ -377,7 +377,7 @@ class TestParametricOperations:
         assert op.qubits is None
         with pytest.raises(
             ValueError,
-            match=f"Operation '{ParamOp.label}' requires {op.num_qubits} qubits, got {op.num_qubits + 6}.",
+            match=f"Operation '{ParamOp.name}' requires {op.num_qubits} qubits, got {op.num_qubits + 6}.",
         ):
             op.qubits = qubits
 
@@ -446,13 +446,13 @@ class TestControlledOperations:
         """Test initializing a controlled operation."""
         control = tuple(f"c{i}" for i in range(ControlledOp.num_control))
         target = tuple(f"t{i}" for i in range(ControlledOp.num_control))
-        label = ControlledOp.label
+        label = ControlledOp.name
 
         op = ControlledOp(control, target)
 
         assert op.control == control
         assert op.target == target
-        assert op.label == label
+        assert op.name == label
 
     def test_initialize_operation_qubits_as_kwargs(self, ControlledOp):
         """Test initializing a controlled operation passing qubits as kwargs."""
@@ -460,13 +460,13 @@ class TestControlledOperations:
         target = tuple(f"t{i}" for i in range(ControlledOp.num_control))
         qubits = control + target
 
-        label = ControlledOp.label
+        label = ControlledOp.name
 
         op = ControlledOp(qubits=qubits)
 
         assert op.control == control
         assert op.target == target
-        assert op.label == label
+        assert op.name == label
 
     def test_initializing_gate_in_context(self, empty_circuit, ControlledOp):
         """Test initializing a controlled operation within a context."""
@@ -534,13 +534,13 @@ class TestParametricControlledOperations:
         params = [f"p{i}" for i in range(ParametricControlledOp.num_parameters)]
         control = tuple(f"c{i}" for i in range(ParametricControlledOp.num_control))
         target = tuple(f"t{i}" for i in range(ParametricControlledOp.num_control))
-        label = ParametricControlledOp.label
+        label = ParametricControlledOp.name
 
         op = ParametricControlledOp(params, control, target)
 
         assert op.control == control
         assert op.target == target
-        assert op.label == f"{label}({op.parameters})"
+        assert op.name == f"{label}({op.parameters})"
 
     def test_initializing_gate_in_context(self, empty_circuit, ParametricControlledOp):
         """Test initializing a parametric controlled operation within a context."""
@@ -624,12 +624,12 @@ class TestOtherOperations:
     def test_initialize_operation(self, Op):
         """Test initializing an operation."""
         qubits = tuple(f"c{i}" for i in range(Op.num_qubits))
-        label = Op.label
+        label = Op.name
 
         op = Op(qubits)
 
         assert op.qubits == qubits
-        assert op.label == label
+        assert op.name == label
 
     def test_initializing_gate_in_context(self, empty_circuit, Op):
         """Test initializing an operation within a context."""
@@ -708,6 +708,6 @@ class TestOtherOperations:
         assert op.qubits is None
         with pytest.raises(
             ValueError,
-            match=f"Operation '{Op.label}' requires {op.num_qubits} qubits, got {op.num_qubits + 6}.",
+            match=f"Operation '{Op.name}' requires {op.num_qubits} qubits, got {op.num_qubits + 6}.",
         ):
             op.qubits = qubits

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -47,7 +47,7 @@ class TestQubit:
     def test_repr(self):
         "Test the representation of a qubit."
         qubit = Qubit("ananas")
-        assert qubit.__repr__() == f"<qubit: ananas, id:{qubit.id}>"
+        assert qubit.__repr__() == f"<qubit: ananas, id: {qubit.id}>"
 
 
 class TestBit:
@@ -80,7 +80,7 @@ class TestBit:
     def test_repr(self):
         "Test the representation of a bit."
         bit = Bit("ananas")
-        assert bit.__repr__() == f"<bit: ananas, id:{bit.id}>"
+        assert bit.__repr__() == f"<bit: ananas, id: {bit.id}>"
 
     @pytest.mark.parametrize("value", [1, 0, "1", True, 42, (1, 2, 3)])
     def test_set_value(self, value):
@@ -89,7 +89,7 @@ class TestBit:
         bit.set(value)
 
         assert bit == int(bool(value))
-        assert bit.__repr__() == f"<bit: banana, id:{bit.id}, value: {int(bool(value))}>"
+        assert bit.__repr__() == f"<bit: banana, id: {bit.id}, value: {int(bool(value))}>"
 
         bit.reset()
 

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -47,7 +47,7 @@ class TestQubit:
     def test_repr(self):
         "Test the representation of a qubit."
         qubit = Qubit("ananas")
-        assert qubit.__repr__() == f"<qubit: ananas, id: {qubit.id}>"
+        assert qubit.__repr__() == f"<qubit: 'ananas', id: {qubit.id}>"
 
 
 class TestBit:
@@ -80,7 +80,7 @@ class TestBit:
     def test_repr(self):
         "Test the representation of a bit."
         bit = Bit("ananas")
-        assert bit.__repr__() == f"<bit: ananas, id: {bit.id}>"
+        assert bit.__repr__() == f"<bit: 'ananas', id: {bit.id}>"
 
     @pytest.mark.parametrize("value", [1, 0, "1", True, 42, (1, 2, 3)])
     def test_set_value(self, value):
@@ -89,7 +89,7 @@ class TestBit:
         bit.set(value)
 
         assert bit == int(bool(value))
-        assert bit.__repr__() == f"<bit: banana, id: {bit.id}, value: {int(bool(value))}>"
+        assert bit.__repr__() == f"<bit: 'banana', id: {bit.id}, value: {int(bool(value))}>"
 
         bit.reset()
 

--- a/tests/test_simulator/test_measurements.py
+++ b/tests/test_simulator/test_measurements.py
@@ -238,9 +238,9 @@ class TestConditionalOps:
             res = simulate(circuit)
 
             if circuit.bits[0].value == 0:
-                assert np.allclose(res, [1/np.sqrt(2), 1/np.sqrt(2), 0, 0])
+                assert np.allclose(res, [1 / np.sqrt(2), 1 / np.sqrt(2), 0, 0])
             else:
-                assert np.allclose(res, [0, 0, 1/np.sqrt(2), 1/np.sqrt(2)])
+                assert np.allclose(res, [0, 0, 1 / np.sqrt(2), 1 / np.sqrt(2)])
 
     def test_measurement_rng_seed(self):
         """Test measurement is reproducible after setting RNG seed."""


### PR DESCRIPTION
* Check types when adding qubits/bits to a circuit and raise a ``TypeError`` if an incorrect type is passed to the method.
* Rename ``label`` to ``name`` for operations.
* Fix inconsistent spacing in primitive object representations. (#17)
* Fix sequential qubit/bit labelling when adding new registers.
* Update operation representations to use ``repr()`` for hashables. (#17)
* Adds `Circuit.get_bit` method (should've been in #23).
* Formats all files using black/isort (mainly affecting `operation_generation`).
* Ignore `operation_generation.py` in coverage since it's already indirectly tested in the simulator tests.

Fixes #17 