### PR TITLE
Update coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,8 +2,7 @@
 branch = True
 plugins = Cython.Coverage
 omit =
-    dwave/gate/simulator/ops.pxd
-    dwave/gate/simulator/operation_generation.py
+    */dwave/gate/simulator/operation_generation.py
 
 [report]
 exclude_lines =

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Tests and coverage can be run using Pytest.
 
 .. code-block:: bash
 
-    pytest tests/ --cov=dwave.gate
+    python -m pytest tests/ --cov=dwave.gate
 
 .. installation-end-marker
 


### PR DESCRIPTION
Coverage seemingly ignores the `omit` section in `.coveragerc` when running in CI. The issue only occurs when running Pytest via its CLI instead of as a Python module due to the omitted file paths being relative to root. This PR updates the omitted file paths so that they're found even if not run from root.

Note that running `python -m pytest` would have worked had it not been for the imports then using the local package (e.g., the relative import paths) instead of the installed package, thus failing to find certain files that have not been built locally.