### PR TITLE
Add QIR compilation support

### DIFF
--- a/dwave/gate/circuit.py
+++ b/dwave/gate/circuit.py
@@ -163,7 +163,7 @@ class Circuit:
         Args:
             operation: Operation to append to the circuit.
         """
-        if self.is_locked() is True:
+        if self.is_locked():
             raise CircuitError(
                 "Circuit is locked and no more operations can be appended. To "
                 "unlock the circuit, call 'Circuit.unlock()' first."
@@ -574,7 +574,7 @@ class Circuit:
 
         Args:
             add_external: Whether to add external functions (not defined in QIR). If ``False``,
-                functions marks as external will be decomposed into valid operations (if possible).
+                functions marked as external will be decomposed into valid operations (if possible).
             bitcode: Whether to return QIR as a legible string or as bitcode.
 
         Returns:
@@ -650,14 +650,14 @@ class ParametricCircuit(Circuit):
         return super().unlock()
 
     def eval(
-        self, parameters: Optional[Sequence[Sequence[complex]]] = None, in_place: bool = False
+        self, parameters: Optional[Sequence[Sequence[complex]]] = None, inplace: bool = False
     ) -> ParametricCircuit:
         """Evaluate circuit operations with explicit parameters.
 
         Args:
             parameters: Parameters to replace operation variables with. Overrides potential variable
                 values. If ``None`` then variable values are used (if existent).
-            in_place: Whether to evaluate the parameters on ``self`` or on a copy
+            inplace: Whether to evaluate the parameters on ``self`` or on a copy
                 of ``self`` (returned).
 
         Returns:
@@ -666,12 +666,12 @@ class ParametricCircuit(Circuit):
         Raises:
             ValueError: If no parameters are passed and if variable has no set value.
         """
-        circuit = self if in_place else copy.deepcopy(self)
+        circuit = self if inplace else copy.deepcopy(self)
 
         for i, op in enumerate(circuit.circuit):
             eval = getattr(op, "eval", None)
             params = parameters[i] if parameters else None
-            circuit.circuit[i] = eval(params, in_place) if eval else op
+            circuit.circuit[i] = eval(params, inplace) if eval else op
 
         return circuit
 

--- a/dwave/gate/circuit.py
+++ b/dwave/gate/circuit.py
@@ -163,7 +163,7 @@ class Circuit:
         Args:
             operation: Operation to append to the circuit.
         """
-        if self.is_locked() == True:
+        if self.is_locked() is True:
             raise CircuitError(
                 "Circuit is locked and no more operations can be appended. To "
                 "unlock the circuit, call 'Circuit.unlock()' first."
@@ -355,7 +355,8 @@ class Circuit:
 
         Args:
             num_qubits: Number of qubits in the quantum register (defaults to 0, i.e., empty).
-            label: Quantum register label (defaults to 'qreg' followed by a incrementing integer starting at 0).
+            label: Quantum register label (defaults to 'qreg' followed by a incrementing
+                integer starting at 0).
         """
         if label is None:
             label = f"qreg{len(self.qregisters)}"
@@ -376,7 +377,8 @@ class Circuit:
 
         Args:
             num_qubits: Number of bits in the classical register (defaults to 0, i.e., empty).
-            label: Classical register label (defaults to 'creg' followed by a incrementing integer starting at 0).
+            label: Classical register label (defaults to 'creg' followed by a incrementing
+                integer starting at 0).
         """
         if label is None:
             label = f"creg{len(self.cregisters)}"
@@ -567,6 +569,45 @@ class Circuit:
 
         return header_str.strip() + "\n\n" + qasm_str.strip()
 
+    def to_qir(self, add_external: bool = False, bitcode: bool = False) -> Union[str, bytes]:
+        """Compile a circuit into QIR.
+
+        Args:
+            add_external: Whether to add external functions (not defined in QIR). If ``False``,
+                functions marks as external will be decomposed into valid operations (if possible).
+            bitcode: Whether to return QIR as a legible string or as bitcode.
+
+        Returns:
+            Union[str, bytes]: The QIR representation of the circuit.
+        """
+        # import outside toplevel to avoid circular imports
+        from dwave.gate.qir.compiler import qir_module
+
+        module = qir_module(self, add_external=add_external)
+        module.compile()
+
+        if bitcode:
+            return module.bitcode
+        return module.qir
+
+    @classmethod
+    def from_qir(cls, qir: Union[str, bytes], bitcode: bool = False) -> Circuit:
+        """Load a circuit from a QIR string or bitcode.
+
+        Args:
+            qir: The QIR string or bitcode to load into a circuit.
+            bitcode: Whether to expect the QIR as a string or as bitcode.
+
+        Returns:
+            Circuit: The circuit represented by the QIR string or bitcode.
+        """
+        # import outside toplevel to avoid circular imports
+        from dwave.gate.qir.loader import load_qir_bitcode, load_qir_string
+
+        if bitcode:
+            return load_qir_bitcode(qir, cls())
+        return load_qir_string(qir, cls())
+
 
 class ParametricCircuit(Circuit):
     """Class to build and manipulate parametric quantum circuits.
@@ -616,7 +657,8 @@ class ParametricCircuit(Circuit):
         Args:
             parameters: Parameters to replace operation variables with. Overrides potential variable
                 values. If ``None`` then variable values are used (if existent).
-            in_place: Whether to evaluate the parameters on ``self`` or on a copy of ``self`` (returned).
+            in_place: Whether to evaluate the parameters on ``self`` or on a copy
+                of ``self`` (returned).
 
         Returns:
             ParametricOperation: Either ``self`` or a copy of ``self``.
@@ -677,7 +719,7 @@ class CircuitContext:
     """
 
     _active_context: Optional[CircuitContext] = None
-    """Optional[CircuitContext]: Current active context; can only be one at a time during runtime."""
+    """Current active context; can only be one at a time during runtime."""
     on_exit_functions: List[Callable] = []
     """List of functions that should be called on context exit. Cleared on context exit."""
 
@@ -743,7 +785,7 @@ class CircuitContext:
         self,
     ) -> Registers:
         """Enters the context and sets itself as active."""
-        if self.circuit.is_locked() == True:
+        if self.circuit.is_locked() is True:
             raise CircuitError(
                 "Circuit is locked and no more operations can be appended. To "
                 "unlock the circuit, call 'Circuit.unlock()' first."

--- a/dwave/gate/operations/base.py
+++ b/dwave/gate/operations/base.py
@@ -383,14 +383,14 @@ class ParametricOperation(Operation):
         return self._parameters
 
     def eval(
-        self, parameters: Optional[Sequence[complex]] = None, in_place: bool = False
+        self, parameters: Optional[Sequence[complex]] = None, inplace: bool = False
     ) -> ParametricOperation:
         """Evaluate operation with explicit parameters.
 
         Args:
             parameters: Parameters to replace operation variables with. Overrides potential variable
                 values. If ``None`` then variable values are used (if existent).
-            in_place: Whether to evaluate the parameters on ``self`` or on a copy of ``self`` (returned).
+            inplace: Whether to evaluate the parameters on ``self`` or on a copy of ``self`` (returned).
 
         Returns:
             ParametricOperation: Either ``self`` or a copy of ``self``.
@@ -398,7 +398,7 @@ class ParametricOperation(Operation):
         Raises:
             ValueError: If no parameters are passed and if variable has no set value.
         """
-        op = self if in_place else copy.deepcopy(self)
+        op = self if inplace else copy.deepcopy(self)
 
         for i, p in enumerate(op.parameters):
             if isinstance(p, Variable):

--- a/dwave/gate/operations/operations.py
+++ b/dwave/gate/operations/operations.py
@@ -51,8 +51,8 @@ __all__ = [
     "CRotation",
     "CSWAP",
     "Fredkin",  # alias
-    "CCNOT",
-    "CCX",  # alias
+    "CCX",
+    "CCNOT",  # alias
     "Toffoli",  # alias
 ]
 
@@ -70,7 +70,6 @@ from dwave.gate.operations.base import (
     ParametricControlledOperation,
     ParametricOperation,
 )
-from dwave.gate.primitives import Qubit
 
 #####################################
 # Non-parametric single-qubit gates #

--- a/dwave/gate/qir/__init__.py
+++ b/dwave/gate/qir/__init__.py
@@ -17,5 +17,26 @@
 Contains the QIR compiler, loader and related files and functions.
 """
 
+from typing import Tuple
+
+try:
+    import pyqir  # noqa: F401
+except ImportError:  # pragma: no cover
+    pyqir_installed = False
+else:
+    # pyqir>=0.8 required
+    # after deprecating py3.7 use importlib.metadata.version instead'
+    from pkg_resources import get_distribution
+    version = lambda v: get_distribution(v).version  # noqa: E731
+
+    def parse(version: str) -> Tuple[str, str, str]:
+        "Parse a MAJOR.MINOR.PATCH version string into a tuple."
+        return tuple(version.split("."))[:3]
+
+    pyqir_installed = parse(version("pyqir")) >= parse("0.8.0")
+
+if not pyqir_installed:  # pragma: no cover
+    raise ImportError("PyQIR not installed.")
+
 from dwave.gate.qir.compiler import *
 from dwave.gate.qir.loader import *

--- a/dwave/gate/qir/__init__.py
+++ b/dwave/gate/qir/__init__.py
@@ -27,6 +27,7 @@ else:
     # pyqir>=0.8 required
     # after deprecating py3.7 use importlib.metadata.version instead'
     from pkg_resources import get_distribution
+
     version = lambda v: get_distribution(v).version  # noqa: E731
 
     def parse(version: str) -> Tuple[str, str, str]:

--- a/dwave/gate/qir/__init__.py
+++ b/dwave/gate/qir/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Quantum Intermediate Representation (QIR) module.
+
+Contains the QIR compiler, loader and related files and functions.
+"""
+
+from dwave.gate.qir.compiler import *
+from dwave.gate.qir.loader import *

--- a/dwave/gate/qir/compiler.py
+++ b/dwave/gate/qir/compiler.py
@@ -1,0 +1,403 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Core QIR compiler.
+
+Contains the core QIR compiler which uses the PyQIR API.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "BaseModule",
+    "qir_module",
+]
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Optional, Sequence
+
+import pyqir
+from pyqir import BasicBlock, Context, Linkage
+from pyqir.rt import initialize
+
+if TYPE_CHECKING:
+    from dwave.gate import Circuit
+
+# from dwave.gate.operations.base import ParametricOperation
+from dwave.gate.qir.instructions import InstrType, Instruction, Operations
+
+
+class CompileError(Exception):
+    """Exception to be raised when there is an error with QIR compilation."""
+
+
+class BaseModule:
+    """Module representing a QIR program conforming to the QIR basic profile.
+
+    Any keyword arguments are directly passed to the internal PyQIR Module.
+    Below are listed the required keyword arguments with their defualt values.
+
+    Args:
+        name: Name of the module.
+        num_qubit: Number of qubits that the module contains.
+        num_bits: Number of bits/results that the module contains.
+        context: The context which the module is tied to. If ``None`` a new context is created.
+
+    Keyword args:
+        qir_major_version: The QIR major version. Defaults to 1.
+        qir_minor_version: The QIR minor version. Defaults to 0.
+        dynamic_qubit_management: Whether to use dynamic qubit management. Defaults to ``False``.
+        dynamic_result_management: Whether to use dynamic result management. Defaults to ``False``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        num_qubits: int,
+        num_bits: int,
+        context: Optional[pyqir.Context] = None,
+        **kwargs,
+    ) -> None:
+        self._is_compiled = False
+
+        self._module_kwargs = kwargs
+        self._module_kwargs.setdefault("qir_major_version", 1)
+        self._module_kwargs.setdefault("qir_minor_version", 0)
+        self._module_kwargs.setdefault("dynamic_qubit_management", False)
+        self._module_kwargs.setdefault("dynamic_result_management", False)
+
+        self._module = pyqir.qir_module(context or Context(), name, **self._module_kwargs)
+
+        self._builder = pyqir.Builder(self.context)
+        self._num_qubits = num_qubits
+        self._num_bits = num_bits
+
+        self._qubits = [pyqir.qubit(self.context, idx) for idx in range(num_qubits)]
+        self._results = [pyqir.result(self.context, idx) for idx in range(num_bits)]
+
+        self._return = None
+        self._return_cmd = None
+
+        # the following keys are determined by the QIR Base Profile
+        self._instructions = {
+            "body": [],
+            "measurements": [],
+            "output": [],
+        }
+
+        self._external_functions: Dict[str, BaseModule.Types] = {}
+
+        @dataclass
+        class Types:
+            """Dataclass for containing QIR types required for external functions.
+
+            Consolidates the use of types instead of relying on pyqir structure and ties the
+            relevant types to the current module, providing a simple type interface.
+            """
+
+            # types that only require the module context
+            VOID = pyqir.Type.void(self.context)
+            DOUBLE = pyqir.Type.double(self.context)
+            QUBIT = pyqir.qubit_type(self.context)
+            RESULT = pyqir.result_type(self.context)
+
+            # integer and boolean types
+            INT32 = pyqir.IntType(self.context, 32)
+            INT64 = pyqir.IntType(self.context, 64)
+            INT_ = INT64
+
+            INT1 = pyqir.IntType(self.context, 1)
+            BOOL_ = INT1
+
+            # types that require arguments
+            function = pyqir.FunctionType
+            pointer = pyqir.PointerType
+
+            # types without constructors
+            ARRAY = pyqir.ArrayType
+            STRUCT = pyqir.StructType
+
+        self.Types = Types
+
+    def compile(self, force: bool = False, strict: bool = True) -> None:
+        """Compile the module and verify it.
+
+        Args:
+            force: Whether to force recompilation if already compiled.
+            set_void_return: Whether to set a ``Void`` return in the final block.
+            strict: Whether the compiler should raise an error if verification fails.
+        """
+        if self._is_compiled:
+            if not force:
+                raise CompileError(
+                    "Module already compiled. Set 'force=True' to force recompilation."
+                )
+            self.reset(rm_instructions=False)
+
+        self._compile()
+
+        self._return = self.builder.ret(self._return_cmd)
+
+        error_msg = self._module.verify()
+        if error_msg is not None and strict:
+            raise CompileError(error_msg)
+
+        self._qir = str(self._module)
+        self._bitcode = self._module.bitcode
+
+        self._is_compiled = True
+
+    def _compile(self) -> None:
+        """Construct the module by adding instructions and blocks."""
+        entry_point = pyqir.entry_point(self._module, "main", self._num_qubits, self._num_bits)
+
+        block = BasicBlock(self.context, "entry", parent=entry_point)
+        self.builder.insert_at_end(block)
+
+        int_type_pointer = pyqir.PointerType(pyqir.IntType(self.context, 8))
+        null_const = pyqir.Constant.null(int_type_pointer)
+        initialize(self.builder, null_const)
+
+        for block_name, instructions in self._instructions.items():
+            # connect to next block
+            block = BasicBlock(self.context, block_name, parent=entry_point)
+            self.builder.br(block)
+            self.builder.insert_at_end(block)
+
+            # add operations
+            for instr in instructions:
+                if block_name == "output":
+                    pyqir.rt.result_record_output(self.builder, instr.args[0], null_const)
+                else:
+                    instr.execute(self.builder)
+
+    @property
+    def name(self) -> str:
+        """Module source filename."""
+        return self._module.source_filename
+
+    @property
+    def qubits(self) -> Sequence[pyqir.Constant]:
+        """QIR module qubit references."""
+        return self._qubits
+
+    @property
+    def results(self) -> Sequence[pyqir.Constant]:
+        """QIR module results/bit references."""
+        return self._results
+
+    @property
+    def context(self) -> pyqir.Context:
+        """Module context."""
+        return self._module.context
+
+    @property
+    def builder(self) -> pyqir.Builder:
+        """Module builder."""
+        return self._builder
+
+    def get_external_instruction(self, name: str, args: Sequence[pyqir.Value]) -> Instruction:
+        """Gets an external function instruction.
+
+        Args:
+            name: The name of the function. Usually lowercase, QIR style,
+                e.g., ``"x"`` or ``cnot``.
+            args: The arguments for applying the function.
+
+        Returns:
+            Optional[pyqir.Function]: Returns the stored external function
+            or ``None`` if not found.
+        """
+        external = self._external_functions.get(name, None)
+
+        return Instruction(InstrType.external, name, args, external)
+
+    @property
+    def qir(self) -> str:
+        """QIR string representation of the circuit.
+
+        Will be compiled if not previously compiled manually.
+
+        Returns:
+            str: QIR string representation.
+        """
+        if not self._is_compiled:
+            self.compile()
+
+        return self._qir
+
+    @property
+    def bitcode(self) -> bytes:
+        """Bitcode representation of the circuit.
+
+        Will be compiled if not previously compiled manually.
+
+        Returns:
+            bytes: A bitcode representation of the QIR circuit.
+        """
+        if not self._is_compiled:
+            self.compile()
+
+        return self._module.bitcode
+
+    def add_instruction(self, block: str, instruction: Instruction) -> None:
+        """Add an instruction (operation) to the module.
+
+        Args:
+            block: The name of the block that the instruction should be added to.
+            instruction: The instruction that should be added.
+        """
+        self._instructions[block].append(instruction)
+
+    def add_external_function(
+        self, name: str, parameter_types: Sequence[BaseModule.Types], return_type=None
+    ) -> None:
+        """Add an external function to the module.
+
+        Args:
+            name: The name of the external function. Preferably lowercase
+                QIR style, e.g., ``"x"`` or ``"cnot"``.
+            parameter_types: Sequence of parameter types to the QIR function.
+            return_type: Return type of the QIR function. If ``None`` (default),
+                return type is set to ``void``.
+        """
+        type_ = self.Types.function(return_type or self.Types.VOID, parameter_types)
+        qis_name = f"__quantum__qis__{name}__body"
+        self._external_functions[name] = pyqir.Function(
+            type_, Linkage.EXTERNAL, qis_name, self._module
+        )
+
+    def set_return(self, ret_cmd: Optional[pyqir.Type.Value] = None, force: bool = False) -> None:
+        """Set the return instruction.
+
+        Will place the return instruction at the end of the final block.
+        If forcing a re-set, the new return will again be placed at the
+        end of the latest block, with the old one removed.
+
+        Args:
+            ret_cmd: The value to return. Returns void if ``None``.
+            force: Whether to replace the former return command with a new one.
+        """
+        if self._return_cmd and not force:
+            raise ValueError(
+                f"Return {self._return_cmd} already set. Replace by passing 'force=True'"
+            )
+        self._return_cmd = ret_cmd
+
+    def reset(self, rm_instructions: bool = True) -> None:
+        """Reset the module for recompilation.
+
+        Args:
+            rm_instructions: Whether to also reset all instructions.
+        """
+        self._module = pyqir.qir_module(self.context, self.name, **self._module_kwargs)
+        self._remove_external_instructions()
+        self._return.erase()
+
+        if rm_instructions:
+            for key in self._instructions:
+                self._instructions[key] = []
+
+            self._return_cmd = None
+
+            self._external_functions.clear()
+        else:
+            # replace all external function with new ones using the _new_ module
+            # must be after the new 'self._module' declaration above
+            for name, exfunc in self._external_functions.items():
+                function_type = self.Types.function(
+                    exfunc.type.ret, [p.type for p in exfunc.params]
+                )
+                self._external_functions[name] = pyqir.Function(
+                    function_type, Linkage.EXTERNAL, exfunc.name, self._module
+                )
+
+        self._is_compiled = False
+        self._qir = self._bitcode = None
+
+    def _remove_external_instructions(self) -> None:
+        """Removes all external functions from the instructions."""
+        for block, instructions in self._instructions.items():
+            instr_len = len(instructions)
+            for i, instr in enumerate(reversed(instructions)):
+                if instr.type is InstrType.external:
+                    del self._instructions[block][instr_len - i - 1]
+
+
+def qir_module(circuit: Circuit, add_external: bool = False) -> BaseModule:
+    """Create a QIR module out of a circuit.
+
+    Args:
+        circuit: Circuit to convert to a QIR module.
+        add_external: Whether to add external function that are not part of the QIR Base Profile.
+
+    Returns:
+        BaseModule: QIR module representing the circuit.
+    """
+    module = BaseModule("Circuit", num_qubits=circuit.num_qubits, num_bits=circuit.num_bits)
+
+    block = "body"
+    for op in circuit.circuit:
+        type_, pyqir_op = Operations.to_qir.get(op.__class__.name, (None, None))
+        if add_external and type_ is InstrType.external:
+            qubit_type = module.Types.QUBIT
+            param_type = module.Types.DOUBLE
+
+            num_parameters = getattr(op, "num_parameters", 0)
+            parameter_types = [qubit_type] * op.num_qubits + [param_type] * num_parameters
+
+            module.add_external_function(pyqir_op, parameter_types=parameter_types)
+
+        args = []
+        if type_ is InstrType.measurement:
+            block = "measurements"
+
+            for qb, b in zip(op.qubits, op.bits):
+                _, qubit_idx = circuit.find_qubit(qb)
+                _, bit_idx = circuit.find_bit(b)
+                args = (module.qubits[qubit_idx], module.results[bit_idx])
+
+                measurement_instruction = Instruction(InstrType.measurement, pyqir_op, args)
+                module.add_instruction("measurements", measurement_instruction)
+
+                output_instruction = Instruction(InstrType.output, "out", [args[1]])
+                module.add_instruction("output", output_instruction)
+
+            continue
+        elif type_ is InstrType.base or (type_ is InstrType.external and add_external):
+            if block == "measurements":
+                raise ValueError(
+                    "Mid-circuit measurements are not supported when compiling to QIR."
+                )
+
+            # if isinstance(op, ParametricOperation):
+            if hasattr(op, "parameters"):
+                args.extend(op.parameters)
+
+            for qb in op.qubits:
+                _, qubit_idx = circuit.find_qubit(qb)
+                args.append(module.qubits[qubit_idx])
+
+            if type_ is InstrType.external:
+                body_instruction = module.get_external_instruction(pyqir_op, args)
+            else:
+                body_instruction = Instruction(InstrType.base, pyqir_op, args)
+
+            module.add_instruction("body", body_instruction)
+        elif type_ is InstrType.decompose or (type_ is InstrType.external and not add_external):
+            raise NotImplementedError("Operation decompositions not supported.")
+        else:
+            raise NotImplementedError(f"Support not implemented for {op.__class__.name} gate.")
+
+    return module

--- a/dwave/gate/qir/instructions.py
+++ b/dwave/gate/qir/instructions.py
@@ -1,0 +1,221 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""QIR instructions, types and Operation transformations.
+
+Contains the Instruction class and the dwave-gate to/from QIR operation transformations.
+"""
+
+__all__ = [
+    "InstrType",
+    "Operations",
+    "Instruction",
+]
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, NamedTuple, Optional, Sequence
+
+import pyqir
+
+
+class InstrType(Enum):
+    base = auto()
+    """Valid QIR base profile instructions"""
+
+    external = auto()
+    """Externally defined instructions. Falls back to decompositions if external
+    functions are disallowed."""
+
+    decompose = auto()
+    """Decomposes operation into valid QIR instructions (or external if allowed)"""
+
+    invalid = auto()
+    """Invalid instructions that should raise an error if used"""
+
+    skip = auto()
+    """Instructions which are ignored when compiling to QIR (e.g., identity operation)"""
+
+    measurement = auto()
+    """Measurement instructions"""
+
+    output = auto()
+    """QIR output instructions"""
+
+
+@dataclass
+class Operations:
+    """Dataclass containing operation transformations between QIR and ``dwave-gate``."""
+
+    Op = NamedTuple("Op", [("type", InstrType), ("name", str)])
+
+    to_qir = {
+        "Identity": Op(InstrType.skip, "id"),
+        "X": Op(InstrType.base, "x"),
+        "Y": Op(InstrType.base, "y"),
+        "Z": Op(InstrType.base, "z"),
+        "Hadamard": Op(InstrType.base, "h"),
+        "S": Op(InstrType.base, "s"),
+        "T": Op(InstrType.base, "t"),
+        "RX": Op(InstrType.base, "rx"),
+        "RY": Op(InstrType.base, "ry"),
+        "RZ": Op(InstrType.base, "rz"),
+        "Rotation": Op(InstrType.external, "rot"),
+        "CX": Op(InstrType.base, "cx"),
+        "CY": Op(InstrType.external, "cy"),
+        "CZ": Op(InstrType.base, "cz"),
+        "SWAP": Op(InstrType.external, "swap"),
+        "CHadamard": Op(InstrType.external, "ch"),
+        "CRX": Op(InstrType.external, "crx"),
+        "CRY": Op(InstrType.external, "cry"),
+        "CRZ": Op(InstrType.external, "crz"),
+        "CRotation": Op(InstrType.external, "crot"),
+        "CSWAP": Op(InstrType.external, "cswap"),
+        "CCX": Op(InstrType.external, "ccnot"),
+        "Measurement": Op(InstrType.measurement, "mz"),
+    }
+
+    from_qir = {v[1]: k for k, v in to_qir.items()}
+
+    from_qis_operation = {
+        f"__quantum__qis__{tup[1]}__body": name
+        for name, tup in to_qir.items()
+        if tup.type not in (InstrType.decompose, InstrType.invalid)
+    }
+
+    # add special cases
+    from_qis_operation.update(
+        {
+            "__quantum__qis__cnot__body": "CX",  # QIR uses CNOT instead of cx (PyQIR)
+        }
+    )
+
+
+class Instruction:
+    """Container class for QIR instructions.
+
+    Args:
+        type_: Instruction type.
+        name: Name of the instruction to be applied.
+        args: QIR arguments to instruction.
+        external: Whether the operation is an external operation.
+    """
+
+    def __init__(
+        self,
+        type_: InstrType,
+        name: str,
+        args: Sequence[Any],
+        external: Optional[pyqir.Function] = None,
+    ) -> None:
+        self._type = type_
+        self._name = name
+
+        self._assert_args(args)
+        self._args = args
+
+        if self.type is InstrType.external and not external:
+            raise ValueError("Instruction with type 'external' missing external function.")
+
+        self._external = external
+
+    def _assert_args(self, args: Sequence[Any]) -> None:
+        """Asserts that ``args`` only contain valid arguments.
+
+        Args:
+            args: Sequence of arguments to check.
+        """
+        for arg in args:
+            if not isinstance(arg, (int, float, pyqir.Constant)):
+                raise TypeError(f"Incorrect type {type(arg)} in arguments.")
+
+    @property
+    def name(self) -> str:
+        """Instruction to apply."""
+        return self._name
+
+    @property
+    def type(self) -> InstrType:
+        """The instruction type."""
+        return self._type
+
+    @property
+    def args(self) -> Sequence[Any]:
+        """Optional arguments to instruction."""
+        return self._args
+
+    def execute(self, builder: pyqir.Builder) -> None:
+        """Executes operation using the provided builder.
+
+        Args:
+            builder: PyQIR module builder.
+        """
+        if self._type in (InstrType.base, InstrType.measurement):
+            self._execute_qis(builder)
+        elif self._type is InstrType.external:
+            self._execute_external(builder)
+        else:
+            raise TypeError(f"Cannot execute instruction of type '{self._type.name}'")
+
+    def _execute_qis(self, builder: pyqir.Builder) -> None:
+        """Executes QIS operation using the provided builder.
+
+        Args:
+            builder: PyQIR module builder.
+        """
+        getattr(pyqir.qis, self.name)(builder, *self.args)
+
+    def _execute_external(self, builder: pyqir.Builder) -> None:
+        """Executes external operation using the provided builder.
+
+        Args:
+            builder: PyQIR module builder.
+        """
+        builder.call(self._external, self.args)
+
+    def __eq__(self, value: object) -> bool:
+        """Whether two instructions are considered equal.
+
+        Two instructions are considered equal if they have the same name, type,
+        number of qubits and number of results.
+        """
+        eq_name = self.name == value.name
+        eq_type = self.type == value.type
+
+        num_qubits_self = [
+            a.type.pointee.name == "Qubit" for a in self.args if isinstance(a, pyqir.Constant)
+        ].count(True)
+
+        num_qubits_value = [
+            a.type.pointee.name == "Qubit" for a in value.args if isinstance(a, pyqir.Constant)
+        ].count(True)
+
+        num_results_self = [
+            a.type.pointee.name == "Result" for a in self.args if isinstance(a, pyqir.Constant)
+        ].count(True)
+
+        num_results_value = [
+            a.type.pointee.name == "Result" for a in value.args if isinstance(a, pyqir.Constant)
+        ].count(True)
+
+        parameters_self = [a for a in self.args if isinstance(a, (int, float))]
+        parameters_value = [a for a in value.args if isinstance(a, (int, float))]
+
+        eq_qubits = num_qubits_self == num_qubits_value
+        eq_results = num_results_self == num_results_value
+        eq_parameters = parameters_self == parameters_value
+
+        if eq_name and eq_type and eq_qubits and eq_results and eq_parameters:
+            return True
+        return False

--- a/dwave/gate/qir/loader.py
+++ b/dwave/gate/qir/loader.py
@@ -75,7 +75,7 @@ def _module_to_circuit(module: Module, circuit: Optional[Circuit] = None) -> Cir
     """Parses a PyQIR module into a ``Circuit`` object.
 
     Args:
-        module: PyyQIR module containing the QIR representation of the circuit.
+        module: PyQIR module containing the QIR representation of the circuit.
         circuit: Optional circuit into which to load QIR bitcode. If ``None``
             a new circuit is created (default).
 
@@ -93,14 +93,14 @@ def _module_to_circuit(module: Module, circuit: Optional[Circuit] = None) -> Cir
     for func in module.functions:
         for block in func.basic_blocks:
             for instr in block.instructions:
-                if instr.opcode == Opcode.RET:
+                if instr.opcode is Opcode.RET:
                     # break block on return code
                     break
 
                 if instr.opcode == Opcode.CALL:
                     # construct and add operations to circuit
                     op_name = Operations.from_qis_operation.get(instr.callee.name, None)
-                    if op_name is InstrType.invalid or "__qis__" not in instr.callee.name:
+                    if "__qis__" not in instr.callee.name:
                         # only add non-ignored QIS operations
                         continue
                     elif op_name is None:
@@ -170,7 +170,7 @@ def _deconstruct_call_instruction(
                 qubits.append(0)
             else:
                 pattern = "\%Qubit\* inttoptr \(i64 (\d+) to \%Qubit\*\)"
-                qubit = re.search(pattern, arg.__str__()).groups()[0]
+                qubit = re.search(pattern, str(arg)).groups()[0]
                 qubits.append(int(qubit) if qubit.isdigit() else None)
         else:
             assert arg.type.pointee.name == "Result"

--- a/dwave/gate/qir/loader.py
+++ b/dwave/gate/qir/loader.py
@@ -1,0 +1,184 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""QIR circuit loader.
+
+Contains the QIR-to-dwave-gate circuit object loaders.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "load_qir_bitcode",
+    "load_qir_string",
+]
+
+import re
+from typing import Optional, Sequence, Tuple
+
+import pyqir
+from pyqir import Context, Module, Opcode
+
+import dwave.gate.operations as ops
+from dwave.gate import Circuit
+from dwave.gate.qir.instructions import InstrType, Operations
+
+
+def load_qir_bitcode(
+    qir_bitcode: bytes, circuit: Optional[Circuit] = None, context: Context = None
+) -> Circuit:
+    """Loads QIR bitcode into a ``Circuit`` object.
+
+    Args:
+        qir_bitcode: QIR bitcode representation of the circuit.
+        circuit: Optional circuit into which to load QIR bitcode. If ``None``
+            a new circuit is created (default).
+        context: Context to use to construct the module.
+
+    Returns:
+        Circuit: Circuit representation of the QIR.
+    """
+    module = Module.from_bitcode(context or Context(), qir_bitcode)
+    return _module_to_circuit(module, circuit)
+
+
+def load_qir_string(
+    qir_str: str, circuit: Optional[Circuit] = None, context: Context = None
+) -> Circuit:
+    """Loads a QIR string into a ``Circuit`` object.
+
+    Args:
+        qir_str: QIR string representation of the circuit.
+        circuit: Optional circuit into which to load QIR bitcode. If ``None``
+            a new circuit is created (default).
+        context: Context to use to construct the module.
+
+    Returns:
+        Circuit: Circuit representation of the QIR.
+    """
+    module = Module.from_ir(context or Context(), qir_str)
+    return _module_to_circuit(module, circuit)
+
+
+def _module_to_circuit(module: Module, circuit: Optional[Circuit] = None) -> Circuit:
+    """Parses a PyQIR module into a ``Circuit`` object.
+
+    Args:
+        module: PyyQIR module containing the QIR representation of the circuit.
+        circuit: Optional circuit into which to load QIR bitcode. If ``None``
+            a new circuit is created (default).
+
+    Returns:
+        Circuit: Circuit representation of the QIR.
+    """
+    if circuit is None:
+        circuit = Circuit()
+
+    qubits = []
+
+    meas_qubits = []
+    meas_bits = []
+
+    for func in module.functions:
+        for block in func.basic_blocks:
+            for instr in block.instructions:
+                if instr.opcode == Opcode.RET:
+                    # break block on return code
+                    break
+
+                if instr.opcode == Opcode.CALL:
+                    # construct and add operations to circuit
+                    op_name = Operations.from_qis_operation.get(instr.callee.name, None)
+                    if op_name is InstrType.invalid or "__qis__" not in instr.callee.name:
+                        # only add non-ignored QIS operations
+                        continue
+                    elif op_name is None:
+                        raise TypeError(f"'{instr.callee.name}' not found in valid QIS operations.")
+
+                    params, qubits, bits = _deconstruct_call_instruction(instr)
+
+                    if op_name == "Measurement":
+                        meas_qubits.extend(qubits)
+                        meas_bits.extend(bits)
+                        # delay adding until all measurements are collected
+                        continue
+
+                    for _ in range(circuit.num_qubits, max(qubits or [0]) + 1):
+                        circuit.add_qubit()
+
+                    circuit.unlock()
+                    with circuit.context as reg:
+                        getattr(ops, op_name)(*params, qubits=[reg.q[qubit] for qubit in qubits])
+
+    # finally, add measurements (if any) to circuit
+    if meas_qubits:
+        _add_measurements(circuit, meas_qubits, meas_bits)
+
+    return circuit
+
+
+def _add_measurements(circuit: Circuit, qubits: Sequence[int], bits: Sequence[int]) -> None:
+    """Add measurements to circuit.
+
+    Args:
+        circuit: The circuit to add the measurments to.
+        qubits: The qubits that are being measured.
+        bits: The bits in which the measurement values are stored.
+    """
+    for _ in range(circuit.num_bits, max(bits or [0]) + 1):
+        circuit.add_bit()
+
+    circuit.unlock()
+    with circuit.context as reg:
+        qubits = [reg.q[qubit] for qubit in qubits]
+        bits = [reg.c[bit] for bit in bits]
+
+        ops.Measurement(qubits=qubits) | bits
+
+
+def _deconstruct_call_instruction(
+    instr: pyqir.Instruction,
+) -> Tuple[Sequence[float], Sequence[int]]:
+    """Extracts parameters and qubits from a call instruction.
+
+    Args:
+        instr: PyQIR instruction to deconstruct.
+
+    Returns:
+        tuple: Containing the parameters and qubits of the instruction/operation.
+    """
+    params = []
+    qubits = []
+    bits = []
+    for arg in instr.args:
+        # only supports doubles
+        if arg.type.is_double:
+            params.append(arg.value)
+        elif arg.type.pointee.name == "Qubit":
+            if arg.is_null:
+                qubits.append(0)
+            else:
+                pattern = "\%Qubit\* inttoptr \(i64 (\d+) to \%Qubit\*\)"
+                qubit = re.search(pattern, arg.__str__()).groups()[0]
+                qubits.append(int(qubit) if qubit.isdigit() else None)
+        else:
+            assert arg.type.pointee.name == "Result"
+            if arg.is_null:
+                bits.append(0)
+            else:
+                pattern = "\%Result\* inttoptr \(i64 (\d+) to \%Result\*\)"
+                bit = re.search(pattern, arg.__str__()).groups()[0]
+                bits.append(int(bit) if bit.isdigit() else None)
+
+    return params, qubits, bits

--- a/dwave/gate/tools/unitary.py
+++ b/dwave/gate/tools/unitary.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 # Circuit functions #
 #####################
 
+
 # TODO: exchange for something better; only here for testing matrix creation
 # for custom operations; controlled operations only works with single
 # control and target; no support for any other multi-qubit gates

--- a/dwave/gate/utils.py
+++ b/dwave/gate/utils.py
@@ -24,7 +24,6 @@ from typing import _GenericAlias
 try:  # pragma: no cover
     from functools import cached_property
 except ImportError:  # pragma: no cover
-
     # Copyright (C) 2006-2013 Python Software Foundation.
     _NOT_FOUND = object()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build-verbosity = "1"
 skip = "pp* *musllinux*"
-before-test = "pip install -r {project}/requirements_dev.txt"
+before-test = "pip install pyqir==0.8.2 && pip install -r {project}/requirements_dev.txt"
 test-command = "pytest {project}/tests"
 before-build = "pip install cgen==2020.1 && python {project}/dwave/gate/simulator/operation_generation.py"
 
@@ -27,6 +27,10 @@ archs = "x86_64 arm64"
 archs = "AMD64"
 # before-build = "pip install delvewheel"
 # repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
+
+[[tool.cibuildwheel.overrides]]
+select = "*aarch64*"
+before-test = "pip install -r {project}/requirements_dev.txt"
 
 [tool.pyright]
 reportUnusedExpression = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.22.4
 cython==0.29.32
 cgen==2020.1
+pyqir==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
     name="dwave-gate",
     install_requires=[
         "numpy",
-        "pyqir>=0.8",
     ],
     ext_modules=cythonize(
         ["dwave/gate/simulator/simulator.pyx",

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     name="dwave-gate",
     install_requires=[
         "numpy",
+        "pyqir>=0.8",
     ],
     ext_modules=cythonize(
         ["dwave/gate/simulator/simulator.pyx",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,12 @@ from dwave.gate.registers import ClassicalRegister, QuantumRegister
 
 
 @pytest.fixture(scope="function")
+def dummy_function():
+    """Dummy function."""
+    return lambda _: None
+
+
+@pytest.fixture(scope="function")
 def two_qubit_circuit():
     """Circuit with two qubits and three operations."""
     circuit = Circuit(2)
@@ -77,7 +83,6 @@ def two_qubit_op(monkeypatch):
     """Empty two-qubit operation."""
 
     class DummyOp(Operation):
-
         _num_qubits: int = 2
 
     monkeypatch.setattr(DummyOp, "__abstractmethods__", set())
@@ -90,7 +95,6 @@ def two_qubit_parametric_op(monkeypatch):
     """Empty two-qubit parametric operation."""
 
     class DummyOp(ParametricOperation):
-
         _num_qubits: int = 2
         _num_params: int = 1
 
@@ -104,7 +108,6 @@ def two_qubit_controlled_op(monkeypatch):
     """Empty two-qubit controlled operation."""
 
     class DummyOp(ControlledOperation):
-
         _num_control: int = 1
         _num_target: int = 1
         _target_operation: Type[Operation] = ops.X

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -797,7 +797,7 @@ class TestParametricCircuit:
             for p in op.parameters:
                 assert isinstance(p, Variable)
 
-        circuit = empty_parametric_circuit.eval([[4.2]], in_place=False)
+        circuit = empty_parametric_circuit.eval([[4.2]], inplace=False)
         for op in circuit.circuit:
             assert op.parameters == [4.2]
             assert isinstance(op.parameters[0], float)
@@ -815,7 +815,7 @@ class TestParametricCircuit:
             for p in op.parameters:
                 assert isinstance(p, Variable)
 
-        empty_parametric_circuit.eval([[4.2]], in_place=True)
+        empty_parametric_circuit.eval([[4.2]], inplace=True)
         for op in empty_parametric_circuit.circuit:
             assert op.parameters == [4.2]
             assert isinstance(op.parameters[0], float)

--- a/tests/test_operations/test_operations.py
+++ b/tests/test_operations/test_operations.py
@@ -389,7 +389,7 @@ class TestParametricOperations:
             assert isinstance(p, Variable)
 
         params = [complex(i) for i in range(ParamOp.num_parameters)]
-        new_op = op.eval(params, in_place=False)
+        new_op = op.eval(params, inplace=False)
         for i, p in enumerate(new_op.parameters):
             assert isinstance(p, complex)
             assert p == params[i]
@@ -406,7 +406,7 @@ class TestParametricOperations:
             assert isinstance(p, Variable)
 
         params = [complex(i) for i in range(ParamOp.num_parameters)]
-        op.eval(params, in_place=True)
+        op.eval(params, inplace=True)
         for i, p in enumerate(op.parameters):
             assert isinstance(p, complex)
             assert p == params[i]

--- a/tests/test_qir/test_compile.py
+++ b/tests/test_qir/test_compile.py
@@ -1,0 +1,535 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import inspect
+import re
+from operator import attrgetter
+from typing import Callable
+
+import pyqir
+import pytest
+
+from dwave.gate import Circuit
+from dwave.gate import operations as ops
+from dwave.gate.qir.compiler import BaseModule, CompileError, qir_module
+from dwave.gate.qir.instructions import InstrType, Instruction, Operations
+
+
+@pytest.fixture(scope="function")
+def two_op_module():
+    """Module with an ``X``, a ``CNOT`` and a ``Measurement`` operation."""
+    mod = BaseModule("QIR_module", 2, 1)
+
+    args_op_0 = (mod.qubits[0],)
+    args_op_1 = (mod.qubits[0], mod.qubits[1])
+    args_meas = (mod.qubits[0], mod.results[0])
+
+    instruction_0 = Instruction(InstrType.base, "x", args_op_0)
+    instruction_1 = Instruction(InstrType.base, "cx", args_op_1)
+    instruction_2 = Instruction(InstrType.measurement, "mz", args_meas)
+
+    mod.add_instruction("body", instruction_0)
+    mod.add_instruction("body", instruction_1)
+    mod.add_instruction("measurements", instruction_2)
+
+    return mod
+
+
+def assert_equal(str_0: str, str_1: str) -> bool:
+    """Assert that two multi-line strings are equal."""
+    for r, e in zip(str_0.split("\n"), str_1.split("\n")):
+        # strip whitespace from each line and check
+        assert r.strip() == e.strip()
+
+
+class TestBaseModule:
+    """Unit tests for the ``BaseModule`` class."""
+
+    @pytest.mark.parametrize(
+        "type_name, pyqir_type, check, result",
+        [
+            ("VOID", pyqir.Type.void(pyqir.Context()), "is_void", True),
+            ("DOUBLE", pyqir.Type.double(pyqir.Context()), "is_double", True),
+            ("QUBIT", pyqir.qubit_type(pyqir.Context()), "pointee.name", "Qubit"),
+            ("RESULT", pyqir.result_type(pyqir.Context()), "pointee.name", "Result"),
+            ("INT32", pyqir.IntType(pyqir.Context(), 32), "width", 32),
+            ("INT64", pyqir.IntType(pyqir.Context(), 64), "width", 64),
+            ("INT_", pyqir.IntType(pyqir.Context(), 64), "width", 64),
+            ("INT1", pyqir.IntType(pyqir.Context(), 1), "width", 1),
+            ("BOOL_", pyqir.IntType(pyqir.Context(), 1), "width", 1),
+        ],
+    )
+    def test_types_class(self, type_name, pyqir_type, check, result):
+        """Test the internal ``BaseModule.Types`` dataclass."""
+        mod = BaseModule("mod", 1, 1)
+
+        assert attrgetter(f"{type_name}.{check}")(mod.Types) == result
+
+    @pytest.mark.parametrize(
+        "type_name, pyqir_type",
+        [
+            ("function", pyqir.FunctionType),
+            ("pointer", pyqir.PointerType),
+            ("ARRAY", pyqir.ArrayType),
+            ("STRUCT", pyqir.StructType),
+        ],
+    )
+    def test_callable_types_class(self, type_name, pyqir_type):
+        """Test the internal ``BaseModule.Types`` dataclass functions."""
+        mod = BaseModule("mod", 1, 1)
+
+        assert isinstance(getattr(mod.Types, type_name), Callable)
+        assert issubclass(getattr(mod.Types, type_name), pyqir_type)
+
+    def test_basemodule(self):
+        """Test the base module's main properties."""
+        context = pyqir.Context()
+        mod = BaseModule("mod_name", 2, 3, context=context)
+
+        assert mod.name == "mod_name"
+
+        assert len(mod.qubits) == 2
+        assert all(q.type.pointee.name == "Qubit" for q in mod.qubits)
+
+        assert len(mod.results) == 3
+        assert all(r.type.pointee.name == "Result" for r in mod.results)
+
+        assert mod.context == context
+
+        assert isinstance(mod.builder, pyqir.Builder)
+
+    def test_reset(self, two_op_module):
+        """Test resetting the module keeping the instructions."""
+        two_op_module.compile()
+
+        assert two_op_module._instructions["body"]
+        assert two_op_module._instructions["measurements"]
+        assert two_op_module._is_compiled
+        assert two_op_module._qir
+        assert "__quantum__qis__x__body" in two_op_module._qir
+        assert two_op_module._bitcode
+
+        two_op_module.reset(rm_instructions=False)
+
+        assert two_op_module._instructions["body"]
+        assert two_op_module._instructions["measurements"]
+        assert not two_op_module._is_compiled
+        assert not two_op_module._qir
+        assert not two_op_module._bitcode
+
+        two_op_module.compile()
+
+        assert two_op_module._is_compiled
+        assert "__quantum__qis__x__body" in two_op_module._qir
+        assert two_op_module._bitcode
+
+    def test_reset_instructions(self, two_op_module):
+        """Test resetting the module including removing instructions."""
+        two_op_module.compile()
+
+        assert two_op_module._instructions["body"]
+        assert two_op_module._instructions["measurements"]
+        assert two_op_module._is_compiled
+
+        two_op_module.reset(rm_instructions=True)
+
+        assert not two_op_module._instructions["body"]
+        assert not two_op_module._instructions["measurements"]
+        assert not two_op_module._is_compiled
+        assert not two_op_module._qir
+        assert not two_op_module._bitcode
+
+        two_op_module.compile()
+
+        assert two_op_module._is_compiled
+        assert "__quantum__qis__x__body" not in two_op_module._qir
+        assert two_op_module._bitcode
+
+    @pytest.mark.parametrize("compile_first", [True, False])
+    def test_qir(self, two_op_module, compile_first):
+        """Test retrieving the QIR string."""
+        assert "__quantum__qis__z__body" not in two_op_module.qir
+
+        two_op_module.add_instruction(
+            "body", Instruction(InstrType.base, "z", [two_op_module.qubits[0]])
+        )
+
+        two_op_module.reset(rm_instructions=False)
+
+        if compile_first:
+            two_op_module.compile()
+        assert "__quantum__qis__z__body" in two_op_module.qir
+
+    @pytest.mark.parametrize("compile_first", [True, False])
+    def test_bitcode(self, two_op_module, compile_first):
+        """Test retrieving the QIR bitcode."""
+        two_op_module.add_instruction(
+            "body", Instruction(InstrType.base, "z", [two_op_module.qubits[0]])
+        )
+
+        if compile_first:
+            two_op_module.compile()
+
+        qir_bitcode = two_op_module.bitcode
+
+        assert qir_bitcode
+
+    def test_external_void_return(self, two_op_module):
+        """Test adding an external function to the module."""
+        qb = two_op_module.Types.QUBIT
+        two_op_module.add_external_function("banana", [qb, qb])
+
+        instr = two_op_module.get_external_instruction("banana", two_op_module.qubits[:2])
+        two_op_module.add_instruction("body", instr)
+
+        assert "__quantum__qis__banana__body" in two_op_module.qir
+
+        two_op_module.reset(rm_instructions=False)
+
+        instr = two_op_module.get_external_instruction("banana", two_op_module.qubits[:2])
+        two_op_module.add_instruction("body", instr)
+
+        assert "__quantum__qis__banana__body" in two_op_module.qir
+
+    def test_return(self, two_op_module):
+        """Test setting a different return value than ``Void``."""
+
+        two_op_module.add_instruction(
+            "body", Instruction(InstrType.base, "z", [two_op_module.qubits[0]])
+        )
+
+        ret_value = two_op_module.results[0]
+        two_op_module.set_return(ret_cmd=ret_value, force=True)
+
+        # set strict to 'False' since other return values than
+        # 'Void' otherwise would raise an exception during validation
+        two_op_module.compile(strict=False)
+
+        qir_str = two_op_module.qir
+
+        assert f"ret {ret_value}" in qir_str
+
+    def test_return_twice(self, two_op_module):
+        """Test validation error."""
+
+        two_op_module.add_instruction(
+            "body", Instruction(InstrType.base, "z", [two_op_module.qubits[0]])
+        )
+
+        ret_value = two_op_module.results[0]
+        two_op_module.set_return(ret_cmd=ret_value, force=True)
+
+        with pytest.raises(CompileError):
+            two_op_module.compile(strict=True)
+
+    def test_return_twice_not_force(self, two_op_module):
+        """Test that the correct error is raised when setting already set return."""
+
+        two_op_module.add_instruction(
+            "body", Instruction(InstrType.base, "z", [two_op_module.qubits[0]])
+        )
+
+        ret_value = two_op_module.results[0]
+        two_op_module.set_return(ret_cmd=ret_value, force=False)
+
+        with pytest.raises(ValueError, match=re.escape(f"Return {ret_value} already set.")):
+            two_op_module.set_return(ret_cmd=ret_value, force=False)
+
+    def test_compile_twice(self, two_op_module):
+        """Test compiling a module twice."""
+
+        two_op_module.add_instruction(
+            "body", Instruction(InstrType.base, "z", [two_op_module.qubits[0]])
+        )
+
+        two_op_module.compile()
+
+        with pytest.raises(CompileError, match="Module already compiled"):
+            two_op_module.compile()
+
+        two_op_module.compile(force=True)
+
+
+class TestQirModuleFunction:
+    """Tests for the ``qir_module``."""
+
+    def test_compiling_circuit(self):
+        """Test compiling a circuit."""
+        circuit = Circuit(2, 2)
+
+        with circuit.context as reg:
+            ops.X(reg.q[0])
+            ops.Y(reg.q[1])
+            ops.Measurement(reg.q) | reg.c
+
+        mod = qir_module(circuit)
+
+        assert mod.name == "Circuit"
+
+        assert len(mod.qubits) == 2
+        assert len(mod.results) == 2
+
+        x_instr = Instruction(InstrType.base, "x", [mod.qubits[0]])
+        y_instr = Instruction(InstrType.base, "y", [mod.qubits[1]])
+        assert mod._instructions["body"] == [x_instr, y_instr]
+
+        q0_meas = Instruction(InstrType.measurement, "mz", [mod.qubits[0], mod.results[0]])
+        q1_meas = Instruction(InstrType.measurement, "mz", [mod.qubits[1], mod.results[1]])
+        assert mod._instructions["measurements"] == [q0_meas, q1_meas]
+
+        r0_meas = Instruction(InstrType.output, "out", [mod.results[0]])
+        r1_meas = Instruction(InstrType.output, "out", [mod.results[1]])
+        assert mod._instructions["output"] == [r0_meas, r1_meas]
+
+    def test_compile_circuit_with_parametric_op(self):
+        """Test compiling a circuit with a parameteric operation."""
+        circuit = Circuit(2)
+
+        with circuit.context as reg:
+            ops.X(reg.q[0])
+            ops.RX(1.2, reg.q[1])
+
+        mod = qir_module(circuit)
+
+        assert len(mod.qubits) == 2
+        assert len(mod.results) == 0
+
+        x_instr = Instruction(InstrType.base, "x", [mod.qubits[0]])
+        rx_instr = Instruction(InstrType.base, "rx", [1.2, mod.qubits[1]])
+        assert mod._instructions["body"] == [x_instr, rx_instr]
+
+    def test_mid_circuit_measurment(self):
+        """Test that an error is raised when having mid-circuit measurments."""
+        circuit = Circuit(2, 2)
+
+        with circuit.context as reg:
+            ops.X(reg.q[0])
+            ops.Measurement(reg.q[0]) | reg.c[0]
+            ops.Y(reg.q[1])
+
+        with pytest.raises(
+            ValueError, match="Mid-circuit measurements are not supported when compiling to QIR."
+        ):
+            _ = qir_module(circuit)
+
+    # TODO: update when decompositions are implemented
+    def test_op_decomposition_not_implemented(self, monkeypatch):
+        """Test that an error is raised when attempting to decompose an
+        operation which has no decompositiond defined."""
+        circuit = Circuit(2, 2)
+
+        with circuit.context as reg:
+            ops.Rotation((0.1, 0.2, 0.3), reg.q[0])
+
+        new_operations_to_qir = Operations.to_qir.copy()
+        new_operations_to_qir.update({"Rotation": Operations.Op(InstrType.decompose, "rot")})
+        monkeypatch.setattr(Operations, "to_qir", new_operations_to_qir)
+
+        assert Operations.to_qir["Rotation"].type == InstrType.decompose
+
+        with pytest.raises(NotImplementedError, match="Operation decompositions not supported."):
+            _ = qir_module(circuit)
+
+    # TODO: update when decompositions are implemented
+    def test_op_decomposition_not_implemented_external(self, monkeypatch):
+        """Test that an error is raised when attempting to decompose an
+        external operation which has no decompositiond defined, when ``external == False``."""
+        circuit = Circuit(2, 2)
+
+        with circuit.context as reg:
+            ops.Rotation((0.1, 0.2, 0.3), reg.q[0])
+
+        assert Operations.to_qir["Rotation"].type == InstrType.external
+
+        with pytest.raises(NotImplementedError, match="Operation decompositions not supported."):
+            _ = qir_module(circuit)
+
+
+class TestCircuitToQIR:
+    """Tests for compiling a circuit into QIR."""
+
+    def test_compile_simple_circuit(self):
+        """Test compiling a circuit into QIR."""
+        circuit = Circuit(2)
+
+        with circuit.context as reg:
+            ops.X(reg.q[0])
+            ops.Y(reg.q[1])
+
+        assert circuit.to_qir(bitcode=True)
+
+        res = circuit.to_qir()
+        exp = inspect.cleandoc(
+            r"""
+            ; ModuleID = 'Circuit'
+            source_filename = "Circuit"
+
+            %Qubit = type opaque
+
+            define void @main() #0 {
+              entry:
+              call void @__quantum__rt__initialize(i8* null)
+              br label %body
+
+            body:                                             ; preds = %entry
+              call void @__quantum__qis__x__body(%Qubit* null)
+              call void @__quantum__qis__y__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+              br label %measurements
+
+            measurements:                                     ; preds = %body
+              br label %output
+
+            output:                                           ; preds = %measurements
+              ret void
+            }
+
+            declare void @__quantum__rt__initialize(i8*)
+
+            declare void @__quantum__qis__x__body(%Qubit*)
+
+            declare void @__quantum__qis__y__body(%Qubit*)
+
+            attributes #0 = { "entry_point" "num_required_qubits"="2" "num_required_results"="0" "output_labeling_schema" "qir_profiles"="custom" }
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        """
+        )
+
+        assert_equal(res, exp)
+
+    def test_compile_circuit_with_measurement(self):
+        """Test compiling a circuit into QIR."""
+        circuit = Circuit(3, 3)
+
+        with circuit.context as reg:
+            ops.X(reg.q[0])
+            ops.CX(reg.q[1], reg.q[2])
+            ops.Measurement(reg.q) | reg.c
+
+        assert circuit.to_qir(add_external=True, bitcode=True)
+
+        res = circuit.to_qir(add_external=True)
+        exp = inspect.cleandoc(
+            r"""
+            ; ModuleID = 'Circuit'
+            source_filename = "Circuit"
+
+            %Qubit = type opaque
+            %Result = type opaque
+
+            define void @main() #0 {
+              entry:
+              call void @__quantum__rt__initialize(i8* null)
+              br label %body
+
+            body:                                             ; preds = %entry
+              call void @__quantum__qis__x__body(%Qubit* null)
+              call void @__quantum__qis__cnot__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              br label %measurements
+
+            measurements:                                     ; preds = %body
+              call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+              br label %output
+
+            output:                                           ; preds = %measurements
+              call void @__quantum__rt__result_record_output(%Result* null, i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__rt__initialize(i8*)
+
+            declare void @__quantum__qis__x__body(%Qubit*)
+
+            declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
+
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+            attributes #0 = { "entry_point" "num_required_qubits"="3" "num_required_results"="3" "output_labeling_schema" "qir_profiles"="custom" }
+            attributes #1 = { "irreversible" }
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        """
+        )
+
+        assert_equal(res, exp)
+
+    def test_compile_circuit_with_external(self):
+        """Test compiling a circuit with external operations into QIR."""
+        circuit = Circuit(3, 2)
+
+        with circuit.context as reg:
+            ops.X(reg.q[0])
+            ops.CY(reg.q[1], reg.q[2])
+
+        assert circuit.to_qir(add_external=True, bitcode=True)
+
+        res = circuit.to_qir(add_external=True)
+        exp = inspect.cleandoc(
+            r"""
+            ; ModuleID = 'Circuit'
+            source_filename = "Circuit"
+
+            %Qubit = type opaque
+
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+
+            define void @main() #0 {
+            entry:
+              call void @__quantum__rt__initialize(i8* null)
+              br label %body
+
+            body:                                             ; preds = %entry
+              call void @__quantum__qis__x__body(%Qubit* null)
+              call void @__quantum__qis__cy__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              br label %measurements
+
+            measurements:                                     ; preds = %body
+              br label %output
+
+            output:                                           ; preds = %measurements
+              ret void
+            }
+
+            declare void @__quantum__rt__initialize(i8*)
+
+            declare void @__quantum__qis__x__body(%Qubit*)
+
+            attributes #0 = { "entry_point" "num_required_qubits"="3" "num_required_results"="2" "output_labeling_schema" "qir_profiles"="custom" }
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        """
+        )
+
+        assert_equal(res, exp)

--- a/tests/test_qir/test_compile.py
+++ b/tests/test_qir/test_compile.py
@@ -17,13 +17,16 @@ import re
 from operator import attrgetter
 from typing import Callable
 
-import pyqir
 import pytest
+
 
 from dwave.gate import Circuit
 from dwave.gate import operations as ops
-from dwave.gate.qir.compiler import BaseModule, CompileError, qir_module
-from dwave.gate.qir.instructions import InstrType, Instruction, Operations
+
+pyqir = pytest.importorskip("pyqir")
+# QIR submodule imports must postcede PyQIR importorskip
+from dwave.gate.qir.compiler import BaseModule, CompileError, qir_module  # noqa: E402
+from dwave.gate.qir.instructions import InstrType, Instruction, Operations  # noqa: E402
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_qir/test_instructions.py
+++ b/tests/test_qir/test_instructions.py
@@ -16,8 +16,10 @@ import itertools
 
 import pytest
 
-from dwave.gate.qir.compiler import BaseModule
-from dwave.gate.qir.instructions import InstrType, Instruction
+pyqir = pytest.importorskip("pyqir")
+# QIR submodule imports must postcede PyQIR importorskip
+from dwave.gate.qir.compiler import BaseModule  # noqa: E402
+from dwave.gate.qir.instructions import InstrType, Instruction  # noqa: E402
 
 
 class TestInstruction:

--- a/tests/test_qir/test_instructions.py
+++ b/tests/test_qir/test_instructions.py
@@ -26,7 +26,7 @@ class TestInstruction:
     """Tests for the ``Instruction`` class."""
 
     @pytest.mark.parametrize(
-        "type_name", ["base", "external", "decompose", "invalid", "skip", "measurement", "output"]
+        "type_name", ["BASE", "EXTERNAL", "DECOMPOSE", "INVALID", "SKIP", "MEASUREMENT", "OUTPUT"]
     )
     def test_instruction(self, type_name, dummy_function):
         """Test the ``Instruction`` initializer."""
@@ -44,9 +44,9 @@ class TestInstruction:
         """Test that the correct exception is raised when passing invalid argument types."""
 
         with pytest.raises(TypeError, match="Incorrect type"):
-            Instruction(InstrType.base, "pomelo", args)
+            Instruction(InstrType.BASE, "pomelo", args)
 
-    @pytest.mark.parametrize("type_name", ["base", "measurement"])
+    @pytest.mark.parametrize("type_name", ["BASE", "MEASUREMENT"])
     def test_excecute_instruction(self, type_name, mocker):
         """Test excecuting instructions."""
         type_ = getattr(InstrType, type_name)
@@ -55,7 +55,7 @@ class TestInstruction:
         mod = BaseModule("QIR_module", 2, 1)
 
         def _assert_qis_called():
-            assert instr.type in (InstrType.base, InstrType.measurement)
+            assert instr.type in (InstrType.BASE, InstrType.MEASUREMENT)
 
         module = Instruction.__module__
         qis_mock = mocker.patch(f"{module}.Instruction._execute_qis")
@@ -67,12 +67,12 @@ class TestInstruction:
 
     def test_excecute_instruction_ext(self, mocker, dummy_function):
         """Test excecuting instructions."""
-        instr = Instruction(InstrType.external, "pomelo", [], external=dummy_function)
+        instr = Instruction(InstrType.EXTERNAL, "pomelo", [], external=dummy_function)
 
         mod = BaseModule("QIR_module", 2, 1)
 
         def _assert_ext_called():
-            assert instr.type is InstrType.external
+            assert instr.type is InstrType.EXTERNAL
 
         module = Instruction.__module__
         ext_mock = mocker.patch(f"{module}.Instruction._execute_external")
@@ -90,9 +90,9 @@ class TestInstruction:
         with pytest.raises(
             ValueError, match="Instruction with type 'external' missing external function."
         ):
-            _ = Instruction(InstrType.external, "pomelo", [])
+            _ = Instruction(InstrType.EXTERNAL, "pomelo", [])
 
-    @pytest.mark.parametrize("type_name", ["decompose", "invalid", "skip", "output"])
+    @pytest.mark.parametrize("type_name", ["DECOMPOSE", "INVALID", "SKIP", "OUTPUT"])
     def test_excecute_instruction_error(self, type_name, monkeypatch):
         """Assert that the correct exception is raised when attempting
         to excecute a non-excecutable instructions."""
@@ -108,16 +108,16 @@ class TestInstruction:
     def test_instruction_equality(self, dummy_function):
         """Test equality between ``Instruction`` objects."""
 
-        instr_0 = Instruction(InstrType.base, "pomelo", [1.2, 2.3])
-        instr_1 = Instruction(InstrType.external, "pomelo", [1.2, 2.3], external=dummy_function)
-        instr_2 = Instruction(InstrType.base, "grapefruit", [1.2, 2.3])
-        instr_3 = Instruction(InstrType.base, "pomelo", [9, 8, 7, 6])
+        instr_0 = Instruction(InstrType.BASE, "pomelo", [1.2, 2.3])
+        instr_1 = Instruction(InstrType.EXTERNAL, "pomelo", [1.2, 2.3], external=dummy_function)
+        instr_2 = Instruction(InstrType.BASE, "grapefruit", [1.2, 2.3])
+        instr_3 = Instruction(InstrType.BASE, "pomelo", [9, 8, 7, 6])
 
         for i0, i1 in itertools.combinations([instr_0, instr_1, instr_2, instr_3], r=2):
             assert i0 != i1
 
-        instr_0_dup = Instruction(InstrType.base, "pomelo", [1.2, 2.3])
-        instr_3_dup = Instruction(InstrType.base, "pomelo", [9.0, 8.0, 7.0, 6.0])
+        instr_0_dup = Instruction(InstrType.BASE, "pomelo", [1.2, 2.3])
+        instr_3_dup = Instruction(InstrType.BASE, "pomelo", [9.0, 8.0, 7.0, 6.0])
 
         assert instr_0 == instr_0_dup
         assert instr_3 == instr_3_dup

--- a/tests/test_qir/test_instructions.py
+++ b/tests/test_qir/test_instructions.py
@@ -1,0 +1,121 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import itertools
+
+import pytest
+
+from dwave.gate.qir.compiler import BaseModule
+from dwave.gate.qir.instructions import InstrType, Instruction
+
+
+class TestInstruction:
+    """Tests for the ``Instruction`` class."""
+
+    @pytest.mark.parametrize(
+        "type_name", ["base", "external", "decompose", "invalid", "skip", "measurement", "output"]
+    )
+    def test_instruction(self, type_name, dummy_function):
+        """Test the ``Instruction`` initializer."""
+        name = "pomelo"
+        args = [1.2, 2.3]
+        type_ = getattr(InstrType, type_name)
+        instr = Instruction(type_, name, args, external=dummy_function)
+
+        assert instr.name == name
+        assert instr.type is type_
+        assert instr.args == args
+
+    @pytest.mark.parametrize("args", [[1 + 2j], [0.1, "hello"]])
+    def test_args_error(self, args):
+        """Test that the correct exception is raised when passing invalid argument types."""
+
+        with pytest.raises(TypeError, match="Incorrect type"):
+            Instruction(InstrType.base, "pomelo", args)
+
+    @pytest.mark.parametrize("type_name", ["base", "measurement"])
+    def test_excecute_instruction(self, type_name, mocker):
+        """Test excecuting instructions."""
+        type_ = getattr(InstrType, type_name)
+        instr = Instruction(type_, "pomelo", [])
+
+        mod = BaseModule("QIR_module", 2, 1)
+
+        def _assert_qis_called():
+            assert instr.type in (InstrType.base, InstrType.measurement)
+
+        module = Instruction.__module__
+        qis_mock = mocker.patch(f"{module}.Instruction._execute_qis")
+        qis_mock.side_effect = lambda _: _assert_qis_called()
+
+        instr.execute(mod.builder)
+
+        qis_mock.assert_called_once()
+
+    def test_excecute_instruction_ext(self, mocker, dummy_function):
+        """Test excecuting instructions."""
+        instr = Instruction(InstrType.external, "pomelo", [], external=dummy_function)
+
+        mod = BaseModule("QIR_module", 2, 1)
+
+        def _assert_ext_called():
+            assert instr.type is InstrType.external
+
+        module = Instruction.__module__
+        ext_mock = mocker.patch(f"{module}.Instruction._execute_external")
+        ext_mock.side_effect = lambda _: _assert_ext_called()
+
+        instr.execute(mod.builder)
+
+        ext_mock.assert_called_once()
+
+    def test_instruction_no_external(
+        self,
+    ):
+        """Test external instruction with no external function."""
+
+        with pytest.raises(
+            ValueError, match="Instruction with type 'external' missing external function."
+        ):
+            _ = Instruction(InstrType.external, "pomelo", [])
+
+    @pytest.mark.parametrize("type_name", ["decompose", "invalid", "skip", "output"])
+    def test_excecute_instruction_error(self, type_name, monkeypatch):
+        """Assert that the correct exception is raised when attempting
+        to excecute a non-excecutable instructions."""
+        args = [1.2, 2.3]
+        type_ = getattr(InstrType, type_name)
+        instr = Instruction(type_, "pomelo", args)
+
+        mod = BaseModule("QIR_module", 2, 1)
+
+        with pytest.raises(TypeError, match="Cannot execute instruction"):
+            instr.execute(mod.builder)
+
+    def test_instruction_equality(self, dummy_function):
+        """Test equality between ``Instruction`` objects."""
+
+        instr_0 = Instruction(InstrType.base, "pomelo", [1.2, 2.3])
+        instr_1 = Instruction(InstrType.external, "pomelo", [1.2, 2.3], external=dummy_function)
+        instr_2 = Instruction(InstrType.base, "grapefruit", [1.2, 2.3])
+        instr_3 = Instruction(InstrType.base, "pomelo", [9, 8, 7, 6])
+
+        for i0, i1 in itertools.combinations([instr_0, instr_1, instr_2, instr_3], r=2):
+            assert i0 != i1
+
+        instr_0_dup = Instruction(InstrType.base, "pomelo", [1.2, 2.3])
+        instr_3_dup = Instruction(InstrType.base, "pomelo", [9.0, 8.0, 7.0, 6.0])
+
+        assert instr_0 == instr_0_dup
+        assert instr_3 == instr_3_dup

--- a/tests/test_qir/test_load.py
+++ b/tests/test_qir/test_load.py
@@ -1,0 +1,224 @@
+# Copyright 2023 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import inspect
+
+import pytest
+
+from dwave.gate import operations as ops
+from dwave.gate.circuit import Circuit
+from dwave.gate.operations.base import Measurement, ParametricOperation
+from dwave.gate.qir.loader import load_qir_string
+
+
+def assert_equal(circuit_0, circuit_1):
+    """Checks two circuits for equality."""
+    assert circuit_0.num_qubits == circuit_1.num_qubits
+    assert circuit_0.num_bits == circuit_1.num_bits
+
+    # check registers (but wait with values, since the qubits/bits will differ)
+    assert circuit_0.qregisters.keys() == circuit_1.qregisters.keys()
+    assert circuit_0.cregisters.keys() == circuit_1.cregisters.keys()
+
+    # check qubit/bit labels (not the qubits/bits themselves since they will differ)
+    qb_labels_0 = [qb.label for qb in circuit_0.qubits]
+    qb_labels_1 = [qb.label for qb in circuit_1.qubits]
+    assert qb_labels_0 == qb_labels_1
+
+    mb_labels_0 = [mb.label for mb in circuit_0.bits]
+    mb_labels_1 = [mb.label for mb in circuit_1.bits]
+    assert mb_labels_0 == mb_labels_1
+
+    # check parametricity of circuits
+    assert circuit_0.parametric == circuit_1.parametric
+    assert circuit_0.num_parameters == circuit_1.num_parameters
+
+    # check number of operations
+    assert len(circuit_0.circuit) == len(circuit_1.circuit)
+
+    # check all operations; their names, qubits, bits and parameters (if required)
+    for op_0, op_1 in zip(circuit_0.circuit, circuit_1.circuit):
+        assert op_0.name == op_1.name
+        assert type(op_0) == type(op_1)
+
+        qb_labels_0 = [qb.label for qb in op_0.qubits]
+        qb_labels_1 = [qb.label for qb in op_1.qubits]
+        assert qb_labels_0 == qb_labels_1
+
+        if isinstance(op_0, Measurement):
+            mb_labels_0 = [mb.label for mb in op_0.bits]
+            mb_labels_1 = [mb.label for mb in op_1.bits]
+            assert mb_labels_0 == mb_labels_1
+
+        if isinstance(op_0, ParametricOperation):
+            assert op_0.parameters == op_1.parameters
+
+
+class TestLoader:
+    """Tests for loading QIR into a circuit."""
+
+    def test_load_qir_string(self):
+        """Test the ``load_qir_string`` function."""
+
+        qir_string = inspect.cleandoc(
+            r"""
+            ; ModuleID = 'Circuit'
+            source_filename = "Circuit"
+
+            %Qubit = type opaque
+            %Result = type opaque
+
+            define void @main() #0 {
+            entry:
+              call void @__quantum__rt__initialize(i8* null)
+              br label %body
+
+            body:                                             ; preds = %entry
+              call void @__quantum__qis__x__body(%Qubit* null)
+              call void @__quantum__qis__ry__body(double 4.200000e+00, %Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__cnot__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              br label %measurements
+
+            measurements:                                     ; preds = %body
+              call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+              br label %output
+
+            output:                                           ; preds = %measurements
+              call void @__quantum__rt__result_record_output(%Result* null, i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__rt__initialize(i8*)
+
+            declare void @__quantum__qis__x__body(%Qubit*)
+
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+
+            declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
+
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+            attributes #0 = { "entry_point" "num_required_qubits"="3" "num_required_results"="3" "output_labeling_schema" "qir_profiles"="custom" }
+            attributes #1 = { "irreversible" }
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        """
+        )
+
+        circuit = load_qir_string(qir_string)
+
+        assert circuit.num_qubits == 3
+        assert circuit.num_bits == 3
+        assert len(circuit.circuit) == 4
+
+        assert circuit.circuit[0].name == "X"
+        assert [qb.label for qb in circuit.circuit[0].qubits] == ["0"]
+
+        assert circuit.circuit[1].name == "RY([4.2])"
+        assert [qb.label for qb in circuit.circuit[1].qubits] == ["2"]
+        assert circuit.circuit[1].parameters == [4.2]
+
+        assert circuit.circuit[2].name == "CX"
+        assert [qb.label for qb in circuit.circuit[2].qubits] == ["1", "2"]
+
+        assert circuit.circuit[3].name == "Measurement"
+        assert [mb.label for mb in circuit.circuit[3].bits] == ["0", "1", "2"]
+        assert [qb.label for qb in circuit.circuit[3].qubits] == ["0", "1", "2"]
+
+    @pytest.mark.parametrize("bitcode", [True, False])
+    def test_to_from_qir(self, bitcode):
+        """Test compiling and loading QIR works."""
+        circuit = Circuit(3, 3)
+
+        with circuit.context as reg:
+            ops.X(reg.q[0])
+            ops.CNOT(reg.q[2], reg.q[0])
+            ops.RY(3.45, reg.q[1])
+            ops.Measurement(reg.q) | reg.c
+
+        qir = circuit.to_qir(bitcode=bitcode)
+        circuit_from_qir = Circuit.from_qir(qir, bitcode=bitcode)
+
+        assert_equal(circuit, circuit_from_qir)
+
+    def test_invalid_qis_operation(self):
+        """Test exception when using non-existent QIS operation."""
+
+        qir_string = inspect.cleandoc(
+            r"""
+            ; ModuleID = 'Citrus'
+            source_filename = "Citrus"
+
+            %Qubit = type opaque
+
+            define void @main() {
+              entry:
+              call void @__quantum__rt__initialize(i8* null)
+              call void @__quantum__qis__xavier__body(%Qubit* null)
+              ret void
+            }
+
+            declare void @__quantum__rt__initialize(i8*)
+            declare void @__quantum__qis__xavier__body(%Qubit*)
+        """
+        )
+        with pytest.raises(TypeError, match="not found in valid QIS operations"):
+            _ = Circuit.from_qir(qir_string)
+
+    def test_load_QIR_into_circuit(self):
+        """Test loading QIR into an existing circuit."""
+        qir_string = inspect.cleandoc(
+            r"""
+            ; ModuleID = 'Citrus'
+            source_filename = "Citrus"
+
+            %Qubit = type opaque
+
+            define void @main() {
+              entry:
+              call void @__quantum__rt__initialize(i8* null)
+              call void @__quantum__qis__y__body(%Qubit* null)
+              ret void
+            }
+
+            declare void @__quantum__rt__initialize(i8*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+        """
+        )
+        circuit = Circuit(2)
+        circuit.append(ops.X(circuit.qubits[0]))
+
+        assert len(circuit.circuit) == 1
+
+        circuit = load_qir_string(qir_string, circuit=circuit)
+
+        assert circuit.num_qubits == 2
+        assert circuit.num_bits == 0
+        assert len(circuit.circuit) == 2
+
+        circuit.unlock()
+        circuit.append(ops.Z(circuit.qubits[0]))
+
+        assert [op.name for op in circuit.circuit] == ["X", "Y", "Z"]

--- a/tests/test_qir/test_load.py
+++ b/tests/test_qir/test_load.py
@@ -19,7 +19,10 @@ import pytest
 from dwave.gate import operations as ops
 from dwave.gate.circuit import Circuit
 from dwave.gate.operations.base import Measurement, ParametricOperation
-from dwave.gate.qir.loader import load_qir_string
+
+pyqir = pytest.importorskip("pyqir")
+# QIR submodule imports must postcede PyQIR importorskip
+from dwave.gate.qir.loader import load_qir_string  # noqa: E402
 
 
 def assert_equal(circuit_0, circuit_1):


### PR DESCRIPTION
Add support for QIR compilation to ``dwave-gate``. This includes support for:

* Compiling arbitrary circuits into QIR following the [QIR Base Profile](https://github.com/qir-alliance/qir-spec/blob/main/specification/under_development/profiles/Base_Profile.md).
* Parsing QIR strings and bitcode and returning a dwave-gate ``Circuit`` object.
* Loading QIR strings and bitcode into existing circuits.

```python
circuit = Circuit(3, 3)

with circuit.context as reg:
    ops.X(reg.q[0])
    ops.CX(reg.q[1], reg.q[2])
    ops.Measurement(reg.q) | reg.c

qir_string = circuit.to_qir()
```

```python
circuit = Circuit.from_qir(qir_string)
```
