### PR TITLE
Add bits to circuit call method

### DIFF
--- a/dwave/gate/operations/base.py
+++ b/dwave/gate/operations/base.py
@@ -53,7 +53,6 @@ from dwave.gate.circuit import Circuit, CircuitContext, CircuitError, Parametric
 from dwave.gate.mixedproperty import mixedproperty
 from dwave.gate.primitives import Bit, Qubit
 from dwave.gate.registers.registers import ClassicalRegister, Variable
-from dwave.gate.simulator.simulator import sample_qubit
 from dwave.gate.tools.unitary import build_controlled_unitary, build_unitary
 
 if TYPE_CHECKING:
@@ -709,6 +708,9 @@ class Measurement(Operation):
         Returns:
             List[Union[int, str]]: The measurement samples for each qubit.
         """
+        # NOTE: avoid circular imports; operations used in simulator
+        from dwave.gate.simulator.simulator import sample_qubit
+
         if self.state is None:
             raise CircuitError(
                 "Measurement has no state. Likely due to circuit not having been simulated."

--- a/releasenotes/notes/fix-sample-circular-import-86ae100745b87464.yaml
+++ b/releasenotes/notes/fix-sample-circular-import-86ae100745b87464.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix circular import issue when importing the simulator prior operations.

--- a/releasenotes/notes/upgrade-circuit-call-bits-f308cc926fa3bce3.yaml
+++ b/releasenotes/notes/upgrade-circuit-call-bits-f308cc926fa3bce3.yaml
@@ -1,0 +1,19 @@
+---
+upgrade:
+  - |
+    Upgrade circuit call to accept classical bits in which to store measurement values. If no bits
+    are passed to the circuit call, measurements will not be stored when circuit is simulated.
+
+    .. code-block:: python
+
+      circuit = Circuit(2, 2)
+
+      with circuit.context as (q, c):
+          ops.Hadamard(q[0])
+          ops.Hadamard(q[1])
+          ops.Measurement(q) | c
+
+      circuit_2 = Circuit(2, 2)
+
+      with circuit_2.context as (q, c):
+          circuit(q, c)  # pass bits to 'circuit'


### PR DESCRIPTION
* Upgrade circuit call to accept classical bits in which to store measurement values. If no bits are passed to the circuit call, measurements will not be stored when circuit is simulated.

  ```python
    circuit = Circuit(2, 2)
    
    with circuit.context as (q, c):
        ops.Hadamard(q[0])
        ops.Hadamard(q[1])
        ops.Measurement(q) | c
    
    circuit_2 = Circuit(2, 2)
    
    with circuit_2.context as (q, c):
        circuit(q, c)  # pass bits to 'circuit'
  ```
* Fixes issue with circular import due to simulator and operations files importing each other (quick fix by moving import to inside sample method).