### PR TITLE
Fix operation call return

### DIFF
--- a/releasenotes/notes/fix-operation-call-return-0d522322ccf0f217.yaml
+++ b/releasenotes/notes/fix-operation-call-return-0d522322ccf0f217.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix return type from ``Operation.__call__`` and subclasses.

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -625,6 +625,19 @@ class TestCircuit:
         with pytest.raises(ValueError, match="already present in the circuit"):
             two_bit_circuit.add_cregister(label="creg0")
 
+    def test_call_operation_instance(self):
+        """Test calling an operation instance."""
+        circuit = Circuit(3)
+        with circuit.context as reg:
+            ops.CNOT(reg.q[0], reg.q[1])(reg.q[1], reg.q[2])(reg.q[2], reg.q[0])
+
+        q0, q1, q2 = circuit.qubits
+
+        assert len(circuit.circuit) == 3
+        assert circuit.circuit[0] == ops.CNOT(q0, q1)
+        assert circuit.circuit[1] == ops.CNOT(q1, q2)
+        assert circuit.circuit[2] == ops.CNOT(q2, q0)
+
     def test_call(self):
         """Test calling the circuit within a context to apply it to the active context."""
         circuit_1 = Circuit(2)

--- a/tests/test_operations/test_operations.py
+++ b/tests/test_operations/test_operations.py
@@ -194,6 +194,20 @@ class TestOperations:
         op.conditional(classical_register[0])
         assert op._cond == (classical_register[0],)
 
+    def test_call_instance(self, Op):
+        """Test returning a new instance by calling an operation instance."""
+        if issubclass(Op, ParametricOperation):
+            op_1 = Op([0 for _ in range(Op.num_parameters)])
+        else:
+            op_1 = Op()
+
+        # parametric operation instances will already contain the set parameters
+        # and can thus directly be called without parameter argument
+        op_2 = op_1()
+
+        assert op_1 == op_2
+        assert op_1 is not op_2
+
 
 class TestCustomOperations:
     """Unit tests for custom operation inheriting from one of the base classes."""


### PR DESCRIPTION
Updates the `Operation.__call__` method (and subclass methods) to return the called operation. This should be expected since calling an operation instance should be the same as applying an operation via the class initialization.