### PR TITLE
Fix QIR load mid-function return

### DIFF
--- a/dwave/gate/qir/loader.py
+++ b/dwave/gate/qir/loader.py
@@ -91,10 +91,16 @@ def _module_to_circuit(module: Module, circuit: Optional[Circuit] = None) -> Cir
     meas_bits = []
 
     for func in module.functions:
+        ret_set = False
         for block in func.basic_blocks:
+            # if return has been set, then ignore rest of blocks
+            if ret_set:
+                break
+
             for instr in block.instructions:
-                if instr.opcode is Opcode.RET:
+                if instr.opcode == Opcode.RET:
                     # break block on return code
+                    ret_set = True
                     break
 
                 if instr.opcode == Opcode.CALL:

--- a/releasenotes/notes/fix-qir-load-midfunc-return-b0f952734e3c6f2a.yaml
+++ b/releasenotes/notes/fix-qir-load-midfunc-return-b0f952734e3c6f2a.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fixes loading QIR scripts with a return mid-function.


### PR DESCRIPTION
Fixes a bug where a return statement in a block which is not the last block of the function is ignored. This fix causes a function to be terminated upon any encountering any `ret` instruction.