### PR TITLE
Fix conditional not propagating with parametric ops

### DIFF
--- a/dwave/gate/circuit.py
+++ b/dwave/gate/circuit.py
@@ -208,7 +208,7 @@ class Circuit:
             # if a parametric operation is called within a non-parameteric circuit, all variables
             # should be replaced by their corresponding parameter values; eval does that
             eval = getattr(operation, "eval", None)
-            operation = eval() if eval else operation
+            operation = eval(inplace=True) if eval else operation
 
         for q in operation.qubits or []:
             if q not in self.qubits:

--- a/releasenotes/notes/fix-cond-not-propagating-5dd63d14836aa27e.yaml
+++ b/releasenotes/notes/fix-cond-not-propagating-5dd63d14836aa27e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updates the circuit so that conditional parametric gates are evaluated in place when appended to
+    the active circuit, fixing an issue where changes to these gates post application are not
+    propagated to the circuit.


### PR DESCRIPTION
When using conditional ops (used for mid-circuit measurements) parametric gates were replaced with copies when evaluated when appended to the active circuit. This caused the conditional modifier not to stick since it was only applied to the original instance and not the copy in the circuit (discovered as a side effect in #46).

```python
with circuit.context as (q, c):
    ...
    RX(np.pi, q[0]).conditional(c[0])
    ...
```
should result in `circuit.circuit` being
```
[..., <ParametricOperation: RX([3.141592653589793]), qubits=(<qubit: '0', id: q03k>,), conditional: (<bit: '0', id: q04j, value: 0>,)>, ...]
```