### PR TITLE
Remove SDK build's "docs_gate/index.rst: WARNING: document isn't in a toctree"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,11 +14,15 @@ dwave-gate
 Documentation
 -------------
 
+.. sdk-start-marker
+
 .. toctree::
     :maxdepth: 1
 
     reference/index
     release_notes
+
+.. sdk-end-marker
 
 .. toctree::
     :caption: Code

--- a/docs/sdk_index.rst
+++ b/docs/sdk_index.rst
@@ -12,12 +12,12 @@ dwave-gate
     :start-after: example-start-marker
     :end-before: example-end-marker
 
-.. toctree::
-    :caption: Documentation
-    :maxdepth: 1
+Documentation
+-------------
 
-    reference/index
-    release_notes
+.. include:: index.rst
+    :start-after: sdk-start-marker
+    :end-before: sdk-end-marker
 
 .. toctree::
     :caption: Code


### PR DESCRIPTION
Both the current and proposed RST files result in identical output but this removes the build warning. 

Part of [sdk](https://github.com/dwavesystems/dwave-ocean-sdk/pull/300), [dimod PR](https://github.com/dwavesystems/dimod/pull/1372), [dwave-system](https://github.com/dwavesystems/dwave-system/pull/524), [dwave-cloud-client](https://github.com/dwavesystems/dwave-cloud-client/pull/633), and [dwave-hybrid](https://github.com/dwavesystems/dwave-hybrid/pull/294) PRs to reduce build warnings