### PR TITLE
Release 0.3.4

### DIFF
--- a/dwave/gate/__init__.py
+++ b/dwave/gate/__init__.py
@@ -16,4 +16,4 @@ from dwave.gate.circuit import *
 from dwave.gate.mixedproperty import *
 from dwave.gate.primitives import *
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"


### PR DESCRIPTION
### Upgrade Notes

- Switch from pkgutil-style namespace package to native namespace package (PEP 420). While native namespace packages and pkgutil-style namespace packages are largely compatible, we recommend using only native ones going forward. See [#56](https://github.com/dwavesystems/dwave-gate/pull/56) 