### PR TITLE
Fix build warnings on invalid escape sequence

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-pydata-sphinx-theme==0.14.3
-sphinx==7.3.7
+pydata-sphinx-theme==0.16.1
+sphinx==8.2.3
 sphinx_autodoc_typehints==1.19.5
 
 reno[sphinx]==3.3.0

--- a/dwave/gate/qir/loader.py
+++ b/dwave/gate/qir/loader.py
@@ -173,7 +173,7 @@ def _deconstruct_call_instruction(
             if arg.is_null:
                 qubits.append(0)
             else:
-                pattern = "\%Qubit\* inttoptr \(i64 (\d+) to \%Qubit\*\)"
+                pattern = r"\%Qubit\* inttoptr \(i64 (\d+) to \%Qubit\*\)"
                 qubit = re.search(pattern, str(arg)).groups()[0]
                 qubits.append(int(qubit) if qubit.isdigit() else None)
         else:
@@ -181,7 +181,7 @@ def _deconstruct_call_instruction(
             if arg.is_null:
                 bits.append(0)
             else:
-                pattern = "\%Result\* inttoptr \(i64 (\d+) to \%Result\*\)"
+                pattern = r"\%Result\* inttoptr \(i64 (\d+) to \%Result\*\)"
                 bit = re.search(pattern, arg.__str__()).groups()[0]
                 bits.append(int(bit) if bit.isdigit() else None)
 


### PR DESCRIPTION
The current patterns' strings' definitions 

```
else:
                pattern = "\%Qubit\* inttoptr \(i64 (\d+) to \%Qubit\*\)"
                qubit = re.search(pattern, str(arg)).groups()[0]
```

cause SDK [build warnings](https://app.circleci.com/pipelines/github/dwavesystems/dwave-ocean-sdk/3387/workflows/4a43a62c-07d8-4543-9a5c-399daf6722b9/jobs/48328) in newer Python versions:

```
<unknown>:176: SyntaxWarning: invalid escape sequence '\%'
<unknown>:184: SyntaxWarning: invalid escape sequence '\%'
```

I tested only by running your [unit test](https://github.com/dwavesystems/dwave-gate/blob/main/tests/test_qir/test_load.py) so you might want to test more.

Also updated sphinx requirements to match current SDK.

