### PR TITLE
Remove aqumen traces

### DIFF
--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -298,7 +298,7 @@ program. You can measure qubits multiple times in a given shot (usually
 resetting the qubit(s) in between).
 
 .. tip::
-    Using the :attr:`~dwave.gate.AqumenResult.tags` property is the recommended way
+    Using the :attr:`~dwave.gate.Result.tags` property is the recommended way
     to organize measurement data.
 
 Measurement outcomes are handled in three different ways:
@@ -310,9 +310,9 @@ Measurement outcomes are handled in three different ways:
     from the other qubits, this data is returned to you in a 3D array
     (per ``tag``) with shape "number of measurements per shot, number of shots,
     number of qubits". This data structure may be retrieved using
-    ``AqumenResult.get_memory``. For circuits with a deterministic number of
+    ``Result.get_memory``. For circuits with a deterministic number of
     measurements per shot consistent for all qubits, this data structure may be
-    converted into a counts dictionary with ``AqumenResult.get_counts``
+    converted into a counts dictionary with ``Result.get_counts``
     (``get_counts`` calls ``get_memory``).
 2.  The outcome may be saved to a register. When doing so, even if the register
     is defined on multiple qubits, only the register copy on the qubit measured
@@ -345,7 +345,7 @@ Measurement outcomes are handled in three different ways:
     number of measurements per shot, you cannot relate measurement outcomes with
     the generating instruction.
 
-By default, the :meth:`~dwave.gate.AqumenResult.get_counts` method returns all data,
+By default, the :meth:`~dwave.gate.Result.get_counts` method returns all data,
 including erasures. To return only results without the ``*``, thereby
 post-selecting on the detected errors, use the ``post_select=True`` flag.
 
@@ -389,8 +389,8 @@ though it were a cross between a print statement and a breakpoint.
 .. todo:: update for Ocean
 
 If your QCDL uses the :meth:`~dwave.gate.qcdl.QcdlModuleContainer.append_table_row`
-method, the :class:`~dwave.gate.AqumenResult` output contains records that you may
-retrieve with :meth:`~AqumenResult.get_records` method.
+method, the :class:`~dwave.gate.Result` output contains records that you may
+retrieve with :meth:`~Result.get_records` method.
 
 .. testcode::
     :skipif: True

--- a/dwave/gate/qcdl/qcdl_circuit.py
+++ b/dwave/gate/qcdl/qcdl_circuit.py
@@ -21,7 +21,7 @@ import inspect
 import logging
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias, overload
+from typing import Any, Callable, Literal, TypeAlias, overload, Protocol
 
 import numpy as np
 
@@ -32,13 +32,29 @@ from .qcdl_models import Qcdl, QcdlModuleName, QcdlProcedureDef
 from .transformer import print_qcdl
 from .utils import is_qubit_or_coupler_name
 
-if TYPE_CHECKING:
-    from aqumen_environment import Environment
-    from aqumen_environment.coupler_graph import CouplerGraph
-    from aqumen_environment.modules import Module
-    from aqumen_hardware_abstraction import Machine
-
 logger = logging.getLogger(__name__)
+
+
+class Environment(Protocol):
+    """Structural type for environments."""
+
+    def get_modules(self, include_couplers: bool) -> Iterable[Any]:
+        ...
+
+
+class Machine(Protocol):
+    """Structural type for machine adapters."""
+
+    environment: Environment
+
+    def get_system(self, name: str) -> QcdlModule:
+        ...
+
+    def set_up_systems(self, systems: dict[str, Any], procedure: Procedure) -> None:
+        ...
+
+    def clean_up_systems(self, systems: dict[str, Any]) -> None:
+        ...
 
 
 class QcdlCircuit(IndexerMixin):
@@ -72,8 +88,7 @@ class QcdlCircuit(IndexerMixin):
     ):
         """Create a QCDL Circuit object
 
-        An environment is only required for certain operations (e.g.,
-        the coupler_graph).
+        An environment is only required for certain operations.
 
         The most common usage for this class is shown in the @qcdl decorator.
 
@@ -126,14 +141,9 @@ class QcdlCircuit(IndexerMixin):
 
         return self._environment
 
-    @property
-    def coupler_graph(self) -> CouplerGraph:
-        return self.environment.coupler_graph
-
     def initialize_modules(
         self,
         main_name: str = "main",
-        modules: Sequence[Module] | None = None,
         **kwargs: Any,
     ) -> dict[str, QcdlModule]:
         """Initialize a dict of QcdlModules
@@ -141,8 +151,6 @@ class QcdlCircuit(IndexerMixin):
         Args:
             main_name (str, optional): Name for the main procedure.
                 Defaults to "main"
-            modules (Sequence[Module] | None, optional): Environment modules.
-                Defaults to using all in the environment.
 
         Raises:
             QCDLUserError: can only do this once
@@ -154,8 +162,7 @@ class QcdlCircuit(IndexerMixin):
         if self._main:
             raise QCDLUserError("Can not create 2 main procedures")
 
-        if modules is None:
-            modules = list(self.environment.get_modules(include_couplers=True))
+        modules = list(self.environment.get_modules(include_couplers=True))
 
         if len(modules) == 0:
             raise QCDLUserError("can not initialize a program with no modules")

--- a/dwave/gate/qcdl/qcdl_objects.py
+++ b/dwave/gate/qcdl/qcdl_objects.py
@@ -73,8 +73,7 @@ def format_signature(
             v = repr(v).replace(" ", "")
             return v
         elif v and isinstance(v, set):
-            # for reproducibility when comparing qcdls, e.g. in
-            # aqumen_web/data/compare_jmz_with_aqumen_service.py
+            # for reproducibility when comparing qcdls
             return "{%s}" % (", ".join(sorted([str(x) for x in v])))
         elif hasattr(v, "name"):
             # e.g., an element

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -38,7 +38,7 @@ from dwave.gate.qcdl.qcdl_models import QcdlStatement
 
 
 def _check_serializable(data):
-    # Aqusim uses multiprocessing which requires that qcdls are pickleable.
+    # ensure that qcdls are pickleable
     assert pickle.loads(pickle.dumps(data)) == data
     raw = data.model_dump(exclude_unset=True)
     assert json.loads(json.dumps(raw)) == raw

--- a/tests/test_qcdl_circuit.py
+++ b/tests/test_qcdl_circuit.py
@@ -35,7 +35,7 @@ from dwave.gate.qcdl.qcdl_models import Qcdl
 
 
 def _check_serializable(data):
-    # Aqusim uses multiprocessing which requires that qcdls are pickleable.
+    # ensure that qcdls are pickleable
     assert pickle.loads(pickle.dumps(data)) == data
     raw = data.model_dump(exclude_unset=True)
     assert json.loads(json.dumps(raw)) == raw

--- a/tests/test_qcdl_circuit.py
+++ b/tests/test_qcdl_circuit.py
@@ -52,14 +52,14 @@ def _assert_statement_count(model, expected=4):
 
 
 class FakeModule:
-    """Minimal stand-in for an aqumen_environment Module."""
+    """Minimal stand-in for an environment Module."""
 
     def __init__(self, name):
         self.name = name
 
 
 class FakeEnv:
-    """Minimal stand-in for an aqumen_environment Environment."""
+    """Minimal stand-in for an environment Environment."""
 
     def __init__(self, qubit_names):
         self._modules = [FakeModule(n) for n in qubit_names]

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -521,7 +521,6 @@ def test_register_is_container():
     def inner(q, register):
         q.rx(0.123)
         # this test handles the case where a register is a QcdlModuleContainer
-        # see https://github.com/quantumcircuits/aqumen_environment/issues/1330
         register += 1
 
     @qcdl(2)
@@ -576,7 +575,6 @@ def test_parent_proc_not_altered():
         q0.rx(0.123)
         # this test handles the case where something containing modules but
         # is not a QcdlModuleContainer is passed
-        # see https://github.com/quantumcircuits/aqumen_environment/issues/1330
         hider.register += 1
 
     @qcdl(1)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -23,7 +23,7 @@ from dwave.gate.qcdl.transformer import transform_qcdl
 
 
 def _check_serializable(data):
-    # Aqusim uses multiprocessing which requires that qcdls are pickleable.
+    # ensure that qcdls are pickleable
     for serializer in [pickle, json]:
         serialized = serializer.dumps(data)
         unserialized = serializer.loads(serialized)


### PR DESCRIPTION
* Removes all mentions of Aqumen (apart for a couple of examples in the docs).
* Removes comments mentioning Aqusim
* Add `Environment` and `Machine` [protocols](https://typing.python.org/en/latest/spec/protocol.html) to replace types.