### PR TITLE
Capitalize qcdl in class names

### DIFF
--- a/docs/qcdl.rst
+++ b/docs/qcdl.rst
@@ -53,5 +53,5 @@ QCDL Development
 
 .. automodule:: dwave.gate.qcdl
     :show-inheritance:
-    :members: Qcdl, QcdlModule, QcdlModuleContainer, QcdlProcedureDef,
-        QcdlStatement
+    :members: QCDLProgram, QCDLModule, QCDLModuleContainer, QCDLProcedureDef,
+        QCDLStatement

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -169,7 +169,7 @@ transpilation collapses your QCDL.
 
 .. note::
     A :func:`~dwave.gate.qcdl.operations.barrier` instruction does not necessarily
-    imply a :meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` (see the
+    imply a :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` (see the
     :ref:`qcdl_advanced_synchronization` section).
 
 .. [#]
@@ -375,12 +375,12 @@ Result Records
 --------------
 
 Results are a Python dictionary where keys are set by the
-:meth:`~dwave.gate.qcdl.QcdlModuleContainer.append_table_row` method and values are
+:meth:`~dwave.gate.qcdl.QCDLModuleContainer.append_table_row` method and values are
 tables formatted as a
 `Polars <https://docs.pola.rs/api/python/stable/reference/index.html>`_
 `DataFrame <https://docs.pola.rs/api/python/stable/reference/dataframe/index.html>`_.
 
-The :meth:`~dwave.gate.qcdl.QcdlModuleContainer.append_table_row` method retrieves
+The :meth:`~dwave.gate.qcdl.QCDLModuleContainer.append_table_row` method retrieves
 the values of registers in runtime. When you invoke the method, register data
 is written to a set of tables that your application can retrieve. In addition to
 using this functionality in algorithms, you can use it for troubleshooting, as
@@ -388,7 +388,7 @@ though it were a cross between a print statement and a breakpoint.
 
 .. todo:: update for Ocean
 
-If your QCDL uses the :meth:`~dwave.gate.qcdl.QcdlModuleContainer.append_table_row`
+If your QCDL uses the :meth:`~dwave.gate.qcdl.QCDLModuleContainer.append_table_row`
 method, the :class:`~dwave.gate.AqumenResult` output contains records that you may
 retrieve with :meth:`~AqumenResult.get_records` method.
 
@@ -668,9 +668,9 @@ complete a measurement on one qubit before another qubit uses that measurement
 as a condition.
 
 You can explicitly control such scheduling with the
-:meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` instruction. You may apply this
+:meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` instruction. You may apply this
 instruction to any number of qubits to indicate that all operations before the
-:meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` instruction must be completed
+:meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` instruction must be completed
 before any operations after the instruction are started.
 
 .. testcode::
@@ -691,12 +691,12 @@ completed.
 Synchronization Considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*   Compilation inserts implicit :meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync`
+*   Compilation inserts implicit :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync`
     instructions before and after all multi-qubit operations such as gates,
     procedures, and control-flow operations (including shots).
-*   The :meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` instruction is not
+*   The :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` instruction is not
     sensitive to the ordering of the qubits.
-*   An explicit :meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` instruction in the
+*   An explicit :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` instruction in the
     program is treated as a :func:`~dwave.gate.qcdl.operations.barrier` instruction
     by the transpiler.
 *   Scheduling is performed at compile-time and there is no support for
@@ -710,13 +710,13 @@ Synchronization Considerations
 .. attention::
     The simulator does not model runtime concurrency; it simply executes
     instructions sequentially regardless of which qubit the instruction uses.
-    Therefore the :meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` instruction does
+    Therefore the :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` instruction does
     not affect execution order of operations.
 
     Consider carefully the positioning of any
-    :meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` and cautiously validate when
+    :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` and cautiously validate when
     executing on a QPU (for example, by using a
-    :meth:`~dwave.gate.qcdl.QcdlModuleContainer.append_table_row` instruction).
+    :meth:`~dwave.gate.qcdl.QCDLModuleContainer.append_table_row` instruction).
 
 .. _qcdl_advanced_conditionals:
 
@@ -791,11 +791,11 @@ Supported Condition Values
     *   -   ``None``
         -   You can separate the steps of evaluating the branch condition and
             branching by assigning the branch condition before the (e.g.,
-            :meth:`~dwave.gate.qcdl.QcdlModuleContainer.If`) statement, with
+            :meth:`~dwave.gate.qcdl.QCDLModuleContainer.If`) statement, with
             that branch condition persisting if ``None`` is specified. The
             branch condition might be set, for example, by a preceding
-            :meth:`~dwave.gate.qcdl.QcdlModuleContainer.all_to_all` or
-            :meth:`~dwave.gate.qcdl.QcdlModule.one_to_all` call, which
+            :meth:`~dwave.gate.qcdl.QCDLModuleContainer.all_to_all` or
+            :meth:`~dwave.gate.qcdl.QCDLModule.one_to_all` call, which
             places a signal from one qubit onto the branch condition of each
             recipient qubit.
         -   See the :ref:`qcdl_advanced_signals` section.
@@ -808,7 +808,7 @@ Guidelines for Using Conditionals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -   You can nest conditional statements arbitrarily deep.
--   Place the :meth:`~dwave.gate.qcdl.QcdlModuleContainer.If` statement and its true
+-   Place the :meth:`~dwave.gate.qcdl.QCDLModuleContainer.If` statement and its true
     and false branches in the same procedure.
 -   Use the :class:`~dwave.gate.qcdl.Scope` class to include an arbitrary number of
     qubits in a condition. If your condition value is an expression, take care
@@ -889,13 +889,13 @@ that condition operations on other qubits.
 Basic Signal
 ~~~~~~~~~~~~
 
-For any qubit, you can set the :attr:`~dwave.gate.qcdl.QcdlModule.signal` property
+For any qubit, you can set the :attr:`~dwave.gate.qcdl.QCDLModule.signal` property
 (the *signal*) to a Boolean value for use, in realtime, as a
 :ref:`branch condition <qcdl_advanced_conditionals>` by other qubits.
 
 The following example results in the bitstring being either :math:`11` or
 :math:`00` (assuming no noise). The
-:meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` operation prevents the
+:meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` operation prevents the
 ``receiver`` qubit conditioning off of the signal value before the ``sender``
 qubit sets it after its measurement. The :ref:`qcdl_advanced_conditionals`
 section describes the condition value used in the ``If`` statement.
@@ -920,12 +920,12 @@ section describes the condition value used in the ``If`` statement.
 
 .. note::
     If more than one qubit is branching off a signal, it is likely more
-    efficient to use the :meth:`~dwave.gate.qcdl.QcdlModule.one_to_all` method.
+    efficient to use the :meth:`~dwave.gate.qcdl.QCDLModule.one_to_all` method.
 
 ``one_to_all`` Signal
 ~~~~~~~~~~~~~~~~~~~~~
 
-The :meth:`~dwave.gate.qcdl.QcdlModule.one_to_all` method signals a Boolean value
+The :meth:`~dwave.gate.qcdl.QCDLModule.one_to_all` method signals a Boolean value
 from one qubit to a set of other qubits that can use it as a
 :ref:`branch condition <qcdl_advanced_conditionals>` to conditionally execute a
 branch of operations.
@@ -959,7 +959,7 @@ value used in the ``If`` statement.
 ``all_to_all`` Signal
 ~~~~~~~~~~~~~~~~~~~~~
 
-The more-general :meth:`~dwave.gate.qcdl.QcdlModuleContainer.all_to_all` method
+The more-general :meth:`~dwave.gate.qcdl.QCDLModuleContainer.all_to_all` method
 signals a Boolean value from all qubits to a set of participating qubits to use
 as a :ref:`branch condition <qcdl_advanced_conditionals>`.
 
@@ -1072,34 +1072,34 @@ QCDL programs support several control-flow mechanisms.\ [#]_
 
     *   -   Method
         -   Purpose
-    *   -   :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Repeat`
+    *   -   :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Repeat`
         -   Repeats the body of the context manager for a specified number of
             iterations.
-    *   -   :meth:`~dwave.gate.qcdl.QcdlModuleContainer.While`
+    *   -   :meth:`~dwave.gate.qcdl.QCDLModuleContainer.While`
         -   Repeats the body of the context manager as long as the condition is
             true.
-    *   -   :meth:`~dwave.gate.qcdl.QcdlModuleContainer.DoWhile`
+    *   -   :meth:`~dwave.gate.qcdl.QCDLModuleContainer.DoWhile`
         -   Unconditionally executes a first iteration of the context manager
             and then, similar to the
-            :meth:`~dwave.gate.qcdl.QcdlModuleContainer.While` method, repeats the
+            :meth:`~dwave.gate.qcdl.QCDLModuleContainer.While` method, repeats the
             body of the context manager as long as the condition is true. Useful
             if the condition is evaluated only within the loop.
-    *   -   :meth:`~dwave.gate.qcdl.QcdlModuleContainer.For`
+    *   -   :meth:`~dwave.gate.qcdl.QCDLModuleContainer.For`
         -   Repeats the body of the context manager as long as the condition is
-            true, similar to the :meth:`~dwave.gate.qcdl.QcdlModuleContainer.While`
+            true, similar to the :meth:`~dwave.gate.qcdl.QCDLModuleContainer.While`
             method, but, similarly to a C-style loop, also provides some
             convenience mechanisms for initializing and updating a register.
-    *   -   :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Break`
+    *   -   :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Break`
         -   Breaks out of a loop structure. Useful for preventing infinite
             loops.
-    *   -   :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Continue`
+    *   -   :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Continue`
         -   Skips the remainder of the body of the context manager and jumps to
             the conditional.
-    *   -   :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Label`/:meth:`~dwave.gate.qcdl.QcdlModuleContainer.Goto`
-        -   A :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Goto` instruction
+    *   -   :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Label`/:meth:`~dwave.gate.qcdl.QCDLModuleContainer.Goto`
+        -   A :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Goto` instruction
             unconditionally jumps to the location marked by the corresponding
-            :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Label` instruction.
-    *   -   :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Return`
+            :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Label` instruction.
+    *   -   :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Return`
         -   Exits a procedure early.
 
 .. [#]
@@ -1132,7 +1132,7 @@ QCDL programs support several control-flow mechanisms.\ [#]_
             rotate(q0, q0, 0.1)
 
 The following is also an example for how a
-:meth:`~dwave.gate.qcdl.QcdlModuleContainer.Repeat` instruction could be
+:meth:`~dwave.gate.qcdl.QCDLModuleContainer.Repeat` instruction could be
 implemented.
 
 .. testcode::

--- a/dwave/gate/qcdl/__init__.py
+++ b/dwave/gate/qcdl/__init__.py
@@ -13,11 +13,11 @@
 #    limitations under the License.
 
 from . import operations
-from .components import QcdlModule, QcdlModuleContainer, Scope, procedure
+from .components import QCDLModule, QCDLModuleContainer, Scope, procedure
 from .constants import LogicalOutcomeToInteger
 from .exceptions import QCDLInternalError, QCDLNotImplementedError, QCDLUserError
 from .qcdl_circuit import qcdl
-from .qcdl_models import Qcdl, QcdlProcedureDef, QcdlStatement
+from .qcdl_models import QCDLProgram, QCDLProcedureDef, QCDLStatement
 from .registers import FixedPointRegister, Register, arbitrary_function
 from .statement import Statement
 from .transformer import display_qcdl, print_qcdl
@@ -28,11 +28,11 @@ __all__ = [
     "QCDLInternalError",
     "QCDLNotImplementedError",
     "QCDLUserError",
-    "Qcdl",
-    "QcdlModule",
-    "QcdlModuleContainer",
-    "QcdlProcedureDef",
-    "QcdlStatement",
+    "QCDLProgram",
+    "QCDLModule",
+    "QCDLModuleContainer",
+    "QCDLProcedureDef",
+    "QCDLStatement",
     "Register",
     "Scope",
     "Statement",

--- a/dwave/gate/qcdl/base.py
+++ b/dwave/gate/qcdl/base.py
@@ -23,11 +23,11 @@ from typing import TYPE_CHECKING, Any
 from .exceptions import QCDLInternalError
 
 if TYPE_CHECKING:
-    from .components import Procedure, QcdlModule
-    from .qcdl_circuit import QcdlCircuit
+    from .components import Procedure, QCDLModule
+    from .qcdl_circuit import QCDLCircuit
 
 
-class QcdlArgument(abc.ABC):
+class QCDLArgument(abc.ABC):
     """This enables passing arbitrary objects to the compiler as args/kwargs to
     a procedure"""
 
@@ -38,23 +38,23 @@ class QcdlArgument(abc.ABC):
         raise NotImplementedError
 
 
-class QcdlModuleContainerBase(QcdlArgument):
-    """This lets you pass an object containing QcdlModules to a procedure"""
+class QCDLModuleContainerBase(QCDLArgument):
+    """This lets you pass an object containing QCDLModules to a procedure"""
 
     @property
     @abc.abstractmethod
-    def qcdl_modules(self) -> Sequence[QcdlModule]:
-        """The QcdlModule(s) this container holds
+    def qcdl_modules(self) -> Sequence[QCDLModule]:
+        """The QCDLModule(s) this container holds
 
         Returns:
-            sequence of QcdlModule
+            sequence of QCDLModule
         """
         raise NotImplementedError
 
     @property
     def name(self) -> str:
         names = ", ".join(m.qcdl_module_name for m in self.qcdl_modules)
-        return f"<QcdlModuleContainerBase {names}>"
+        return f"<QCDLModuleContainerBase {names}>"
 
     def serialize(self) -> list[str]:
         return [m.qcdl_module_name for m in self.qcdl_modules]
@@ -74,7 +74,7 @@ class QcdlModuleContainerBase(QcdlArgument):
         return proc
 
     @property
-    def state(self) -> QcdlCircuit:
+    def state(self) -> QCDLCircuit:
         return self.procedure.state
 
     def __str__(self) -> str:
@@ -82,14 +82,14 @@ class QcdlModuleContainerBase(QcdlArgument):
 
     @property
     def op_key(self) -> str | None:
-        """Intended to represent the contents of a QcdlModuleContainerBase
+        """Intended to represent the contents of a QCDLModuleContainerBase
         besides its qcdl_modules, used for procedure names when this is an
         argument.
         """
         return None
 
     def set_procedure(self, new_proc: Procedure) -> None:
-        """Rewrap the QcdlModule objects with the new procedure
+        """Rewrap the QCDLModule objects with the new procedure
 
         The default implementation assumes that `qcdl_modules` is a list.
 
@@ -98,10 +98,10 @@ class QcdlModuleContainerBase(QcdlArgument):
         """
 
         for idx, m in enumerate(self.qcdl_modules):
-            if isinstance(m, QcdlModuleContainerBase) and not m._is_qcdl_module:
+            if isinstance(m, QCDLModuleContainerBase) and not m._is_qcdl_module:
                 m.set_procedure(new_proc)
             else:
-                # QcdlModule's qcdl_modules is not mutable
+                # QCDLModule's qcdl_modules is not mutable
                 if not isinstance(self.qcdl_modules, MutableSequence):
                     raise QCDLInternalError(
                         f"the default implementation only supports list,"
@@ -111,7 +111,7 @@ class QcdlModuleContainerBase(QcdlArgument):
                 self.qcdl_modules[idx] = m.from_rewrapping(m, new_proc=new_proc)
 
 
-class VariableExpression(QcdlArgument):
+class VariableExpression(QCDLArgument):
     """A QCDL variable expression
 
     This is a compile-time expression.
@@ -270,7 +270,7 @@ class VariableExpression(QcdlArgument):
         return self._apply_operator("%", operand)
 
 
-class Variable(QcdlArgument):
+class Variable(QCDLArgument):
     """This is the QCDL approach for creating a QCDL Variable
 
     Corresponds 1-to-1 with the qcdl_objects.py Variable. There will be
@@ -295,7 +295,7 @@ class Variable(QcdlArgument):
 
 
 class IndexerMixin:
-    """This is used as a mixin for Procedure and QcdlCircuit"""
+    """This is used as a mixin for Procedure and QCDLCircuit"""
 
     def __init__(self, next_indices: dict[str, int] | None = None) -> None:
         self._next_indices: defaultdict[str, int] = defaultdict(lambda: 0)

--- a/dwave/gate/qcdl/components.py
+++ b/dwave/gate/qcdl/components.py
@@ -32,14 +32,14 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 import numpy as np
 
-from .base import IndexerMixin, QcdlArgument, QcdlModuleContainerBase
+from .base import IndexerMixin, QCDLArgument, QCDLModuleContainerBase
 from .constants import MIN_INT_REGISTER_VALUE, NUM_RECS
 from .exceptions import QCDLInternalError, QCDLUserError
 from .qcdl_models import (
-    QcdlModuleName,
-    QcdlProcedureDef,
-    QcdlSignature,
-    QcdlStatement,
+    QCDLModuleName,
+    QCDLProcedureDef,
+    QCDLSignature,
+    QCDLStatement,
 )
 from .records import RecordOutput
 from .registers import (
@@ -54,7 +54,7 @@ from .statement import Statement  # noqa: F401  kept for public API
 from .utils import map_container, objwalk
 
 if TYPE_CHECKING:
-    from .qcdl_circuit import QcdlCircuit
+    from .qcdl_circuit import QCDLCircuit
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ class StatementToHashEncoder(json.JSONEncoder):
     """
 
     def default(self, obj: Any) -> Any:
-        if isinstance(obj, QcdlStatementBridge):
+        if isinstance(obj, QCDLStatementBridge):
             return str(obj)
         elif hasattr(obj, "unique_name"):
             return obj.unique_name
@@ -85,8 +85,8 @@ class Procedure(IndexerMixin):
             unique, the @procedure decorator will incorporate the
             args/kwargs (or a hash thereof) to create a "mangled" version of
             the name.
-        state (QcdlCircuit): the state of the overall circuit
-        modules (list[QcdlModule] | None, optional): modules refers to the externally
+        state (QCDLCircuit): the state of the overall circuit
+        modules (list[QCDLModule] | None, optional): modules refers to the externally
             facing method signature if set to None, then it will be taken
             from modules_used (i.e., determine the signature based on the
             statements). Defaults to None.
@@ -102,8 +102,8 @@ class Procedure(IndexerMixin):
     def __init__(
         self,
         proc_name: str,
-        state: QcdlCircuit,
-        modules: list[QcdlModule] | None = None,
+        state: QCDLCircuit,
+        modules: list[QCDLModule] | None = None,
         args: Sequence[Any] | None = None,
         kwargs: Mapping[Any, Any] | None = None,
         qcdl_operator: str | None = None,
@@ -114,14 +114,14 @@ class Procedure(IndexerMixin):
         self.state = state
         self.modules = modules
         self.is_main = is_main
-        self.statements: list[QcdlStatement] = []
+        self.statements: list[QCDLStatement] = []
         self._expression_queue: list[Any] | None = None
         self._child_proc: Procedure | None = None
 
         # modules_used tracks which modules are actually used which may
         # include ones not in the signature.
         # for example, `q0.swap(q1)` might include coupler c0
-        self.modules_used: list[QcdlModuleName] = []
+        self.modules_used: list[QCDLModuleName] = []
 
         self.args = args or []
         self.kwargs = kwargs or {}
@@ -140,7 +140,7 @@ class Procedure(IndexerMixin):
 
         self._procedure_ended = False
 
-    def to_model(self) -> QcdlProcedureDef:
+    def to_model(self) -> QCDLProcedureDef:
         """The encoded version of the python code
 
         NOTE: The compiler calls the fields qubits and qubits_used, even
@@ -153,19 +153,19 @@ class Procedure(IndexerMixin):
             )
 
         if self.modules:
-            qubits: list[QcdlModuleName] = [
-                QcdlModuleName.model_validate(str(q)) for q in self.modules
+            qubits: list[QCDLModuleName] = [
+                QCDLModuleName.model_validate(str(q)) for q in self.modules
             ]
         else:
             qubits = list(self.modules_used)
-        signature = QcdlSignature(
+        signature = QCDLSignature(
             qcdl_operator=self.qcdl_operator,
             qubits=qubits,
             qubits_used=list(self.modules_used),
-            args=QcdlModule.unwrap(self.args),
-            kwargs=QcdlModule.unwrap(self.kwargs),
+            args=QCDLModule.unwrap(self.args),
+            kwargs=QCDLModule.unwrap(self.kwargs),
         )
-        return QcdlProcedureDef(
+        return QCDLProcedureDef(
             statements=self.statements,
             statement_hash=self.statement_hash,
             signature=signature,
@@ -242,7 +242,7 @@ class Procedure(IndexerMixin):
         """
         if module_name is None:
             return
-        module = QcdlModuleName.model_validate(module_name)
+        module = QCDLModuleName.model_validate(module_name)
         if module not in self.modules_used:
             self.modules_used.append(module)
 
@@ -326,15 +326,15 @@ class Procedure(IndexerMixin):
                 " while a cpu expression queue is active"
             )
 
-        args = QcdlModule.unwrap(args)
-        kwargs = QcdlModule.unwrap(kwargs)
+        args = QCDLModule.unwrap(args)
+        kwargs = QCDLModule.unwrap(kwargs)
 
-        stmt = QcdlStatement(
+        stmt = QCDLStatement(
             op=op,
-            qubit=QcdlModuleName.model_validate(qubit) if qubit is not None else None,
+            qubit=QCDLModuleName.model_validate(qubit) if qubit is not None else None,
             args=list(args) if args else [],
             kwargs=dict(kwargs) if kwargs else {},
-            caller_qubits=[QcdlModuleName.model_validate(q) for q in caller_qubits]
+            caller_qubits=[QCDLModuleName.model_validate(q) for q in caller_qubits]
             if caller_qubits
             else [],
         )
@@ -370,8 +370,8 @@ class Procedure(IndexerMixin):
     def __getattr__(self, procedure_name: str) -> Callable[..., None]:
         """Call one procedure from another
 
-        This is similar to __getattr__ on QcdlModules except that
-        it can be invoked from a procedure instead of from a QcdlModule.
+        This is similar to __getattr__ on QCDLModules except that
+        it can be invoked from a procedure instead of from a QCDLModule.
         The called procedure must have been ended so that this method
         can determine which qubits are sent to it using its signature.
 
@@ -401,18 +401,18 @@ class Procedure(IndexerMixin):
 
         return f
 
-    def q(self, name: str | int) -> QcdlModule:
-        """Dynamically get a qubit QcdlModule
+    def q(self, name: str | int) -> QCDLModule:
+        """Dynamically get a qubit QCDLModule
 
         Args:
             name (str or int): name of the module
 
         Returns:
-            QcdlModule: module ready for your instructions
+            QCDLModule: module ready for your instructions
         """
         if isinstance(name, int):
             name = "q%i" % name
-        return QcdlModule(name, self)
+        return QCDLModule(name, self)
 
     def __str__(self) -> str:
         return "<Procedure %s>" % self.proc_name
@@ -421,8 +421,8 @@ class Procedure(IndexerMixin):
         return str(self)
 
 
-class QcdlStatementBridge:
-    """Object that tracks if a getattr from QcdlModule ever gets resolved"""
+class QCDLStatementBridge:
+    """Object that tracks if a getattr from QCDLModule ever gets resolved"""
 
     def __init__(self, proc: Procedure, qubit_name: str, method_name: str):
         self._proc = proc
@@ -436,13 +436,13 @@ class QcdlStatementBridge:
         self._proc.add_statement(self._qubit_name, self._method_name, args, kwargs)
 
 
-class QcdlModuleContainer(QcdlModuleContainerBase):
-    """Base class for the :class:`.QcdlModule` and :class:`.Scope` classes.
+class QCDLModuleContainer(QCDLModuleContainerBase):
+    """Base class for the :class:`.QCDLModule` and :class:`.Scope` classes.
 
     Defines shared methods such as
-    :meth:`~dwave.gate.qcdl.QcdlModuleContainer.If`,
-    :meth:`~dwave.gate.qcdl.QcdlModuleContainer.comment`, and
-    :meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync`.
+    :meth:`~dwave.gate.qcdl.QCDLModuleContainer.If`,
+    :meth:`~dwave.gate.qcdl.QCDLModuleContainer.comment`, and
+    :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync`.
 
     This class is not meant to be instantiated directly. Typical QCDL programs
     use the :class:`.Scope` class.
@@ -464,7 +464,7 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
 
     def _If(
         self,
-        condition: RegisterExpression | QcdlModule | bool | str | None,
+        condition: RegisterExpression | QCDLModule | bool | str | None,
         all_sources_identical: bool = True,
         debug: bool = False,
         _exclusivity: bool = False,
@@ -511,7 +511,7 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
     @contextmanager
     def If(
         self,
-        condition: RegisterExpression | QcdlModule | bool | str | None,
+        condition: RegisterExpression | QCDLModule | bool | str | None,
         all_sources_identical: bool = True,
         debug: bool = False,
         true_goto: str | None = None,
@@ -521,7 +521,7 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
     ) -> Iterator[Callable[..., Any]]:
         """Conditionally execute an expression.
 
-        All qubits in this :class:`.QcdlModuleContainer` participate in the
+        All qubits in this :class:`.QCDLModuleContainer` participate in the
         conditional. See the :ref:`qcdl_advanced_conditionals` section for
         information on conditional branching.
 
@@ -704,14 +704,14 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
     @contextmanager
     def While(
         self,
-        condition: RegisterExpression | QcdlModule | bool | str | None = None,
+        condition: RegisterExpression | QCDLModule | bool | str | None = None,
         all_sources_identical: bool = True,
         _base_name: str = "while",
         _base_idx: int | None = None,
     ) -> Iterator[None]:
         """Execute context statements while condition is true.
 
-        All qubits in this :class:`.QcdlModuleContainer` participate in the
+        All qubits in this :class:`.QCDLModuleContainer` participate in the
         conditional. See the :ref:`qcdl_advanced_conditionals` section for
         information on conditional branching.
 
@@ -755,12 +755,12 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
     @contextmanager
     def DoWhile(
         self,
-        condition: RegisterExpression | QcdlModule | bool | str | None = None,
+        condition: RegisterExpression | QCDLModule | bool | str | None = None,
         all_sources_identical: bool = True,
     ) -> Iterator[None]:
         """Execute context statements while condition is true, and at least once.
 
-        All qubits in this :class:`.QcdlModuleContainer` participate in the
+        All qubits in this :class:`.QCDLModuleContainer` participate in the
         conditional. See the :ref:`qcdl_advanced_conditionals` section for
         information on conditional branching.
 
@@ -823,7 +823,7 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
         An almost C-style for loop, similar to a :meth:`.While` loop with minor
         enhancement.
 
-        All qubits in this :class:`.QcdlModuleContainer` participate in the
+        All qubits in this :class:`.QCDLModuleContainer` participate in the
         conditional. See the :ref:`qcdl_advanced_conditionals` section for
         information on conditional branching.
 
@@ -881,7 +881,7 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
     ) -> Iterator[Register]:
         """Loop over a fixed number of iterations.
 
-        All qubits in this :class:`.QcdlModuleContainer` participate in the
+        All qubits in this :class:`.QCDLModuleContainer` participate in the
         loop.
 
         Args:
@@ -1385,17 +1385,17 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
         _type_error_raises (bool): If True, if the requested _impl isn't
             compatible with the method on the qubit, then raise the TypeError
             exception instead of falling back to add_statement (see code).
-        _allow_override (bool): If the instance is not a :class:`QcdlModule`, then this
+        _allow_override (bool): If the instance is not a :class:`QCDLModule`, then this
             would allow subclasses or other implementations to override
-            :class:`QcdlModule`'s method.
+            :class:`QCDLModule`'s method.
         """
         q, others = self.qcdl_modules[0], self.qcdl_modules[1:]
 
         def _stmt(name: Any, args: Any, kwargs: Any) -> None:
             use_add_statement = True
             if (
-                _allow_override and hasattr(q, op) and type(q) is not QcdlModule
-            ):  # Implicitly check if it is either a System or SystemQcdlModule
+                _allow_override and hasattr(q, op) and type(q) is not QCDLModule
+            ):  # Implicitly check if it is either a System or SystemQCDLModule
                 # check if it's possible to call on the qubit directly
                 f = getattr(q, op)
                 sig = inspect.signature(f)
@@ -1663,15 +1663,15 @@ class QcdlModuleContainer(QcdlModuleContainerBase):
         return shape, table_row
 
 
-class QcdlModule(QcdlModuleContainer):
+class QCDLModule(QCDLModuleContainer):
     """Wrapper around a :class:`.Procedure` instance.
 
     .. important:: This class is intended for use by developers of QCDL to
         append instructions to a module, typically a qubit.
 
-    A :class:`QcdlModule` instance is associated with a specific
+    A :class:`QCDLModule` instance is associated with a specific
     :class:`.Procedure` instance. This means that if a procedure is entered, a
-    new :class:`.QcdlModule` is instantiated.
+    new :class:`.QCDLModule` is instantiated.
 
     This class is designed to provide an intuitive and convenient way to call
     the :meth:`~dwave.gate.qcdl.components.Procedure.add_statement` method. It does
@@ -1682,12 +1682,12 @@ class QcdlModule(QcdlModuleContainer):
 
     Args:
         module_name (str): Name of the module, typically a qubit.
-        proc (Procedure): :class:`.Procedure` instance this :class:`.QcdlModule`
+        proc (Procedure): :class:`.Procedure` instance this :class:`.QCDLModule`
             is in.
 
     Examples:
         This example shows a typical use of :mod:`~dwave.gate.qcdl.operations`
-        methods, which indirectly instantiates a :class:`QcdlModule` instance.
+        methods, which indirectly instantiates a :class:`QCDLModule` instance.
 
         .. testcode::
 
@@ -1703,8 +1703,8 @@ class QcdlModule(QcdlModuleContainer):
             qcdl_program = direct_op()
 
         The code above prints the
-        :attr:`~dwave.gate.qcdl.QcdlModule.qcdl_module_name` property of the
-        :class:`QcdlModule` class.
+        :attr:`~dwave.gate.qcdl.QCDLModule.qcdl_module_name` property of the
+        :class:`QCDLModule` class.
 
         .. testoutput::
 
@@ -1747,24 +1747,24 @@ class QcdlModule(QcdlModuleContainer):
         return True
 
     @staticmethod
-    def from_rewrapping(m: QcdlModule, new_proc: Procedure) -> QcdlModule:
-        """Repackage a QcdlModule to be appropriate to the procedure scope.
+    def from_rewrapping(m: QCDLModule, new_proc: Procedure) -> QCDLModule:
+        """Repackage a QCDLModule to be appropriate to the procedure scope.
 
         Args:
-            m (QcdlModule): original QcdlModule
+            m (QCDLModule): original QCDLModule
             new_proc (Procedure): The new procedure to wrap it in.
 
         Returns:
-            QcdlModule: rewrapped QcdlModule
+            QCDLModule: rewrapped QCDLModule
 
         :meta private:
         """
         proc = new_proc or m.procedure
-        return QcdlModule(m.qcdl_module_name, proc)
+        return QCDLModule(m.qcdl_module_name, proc)
 
     @property
-    def qcdl_modules(self) -> tuple[QcdlModule]:
-        """tuple[QcdlModule]: The :class:`~dwave.gate.qcdl.QcdlModule` this
+    def qcdl_modules(self) -> tuple[QCDLModule]:
+        """tuple[QCDLModule]: The :class:`~dwave.gate.qcdl.QCDLModule` this
         container holds."""
         # use a tuple so that it's not editable
         return (self,)
@@ -1817,7 +1817,7 @@ class QcdlModule(QcdlModuleContainer):
         return self._proc
 
     @classmethod
-    def find_modules(cls, *args: Any, **kwargs: Any) -> Iterator[QcdlModule]:
+    def find_modules(cls, *args: Any, **kwargs: Any) -> Iterator[QCDLModule]:
         """Find all unique modules from the args and kwargs
 
         Some statements need to do something for every module, for example,
@@ -1828,7 +1828,7 @@ class QcdlModule(QcdlModuleContainer):
         will recursively search all args and kwargs for any modules.
 
         Yields:
-            QcdlModule: modules
+            QCDLModule: modules
 
         :meta private:
         """
@@ -1840,14 +1840,14 @@ class QcdlModule(QcdlModuleContainer):
                 if a.qcdl_module_name not in returned:
                     yield a
                 returned[a.qcdl_module_name] = a
-            elif isinstance(a, QcdlModuleContainerBase):
+            elif isinstance(a, QCDLModuleContainerBase):
                 for q in a.qcdl_modules:
                     if q.qcdl_module_name not in returned:
                         yield q
                     returned[q.qcdl_module_name] = q
 
-    def get_other_qcdl_module(self, module_name: str) -> QcdlModule:
-        """Create an ad hoc :class:`QcdlModule` in the same procedure.
+    def get_other_qcdl_module(self, module_name: str) -> QCDLModule:
+        """Create an ad hoc :class:`QCDLModule` in the same procedure.
 
         Applying instructions to this will automatically register it as one of
         the modules used by this procedure.
@@ -1860,7 +1860,7 @@ class QcdlModule(QcdlModuleContainer):
             QCDLUserError: Other module is not in this procedure.
 
         Returns:
-            QcdlModule: The other module is in this same procedure scope.
+            QCDLModule: The other module is in this same procedure scope.
         """
         if not self.state.all_modules:
             raise QCDLInternalError(
@@ -1871,7 +1871,7 @@ class QcdlModule(QcdlModuleContainer):
                 f"module {module_name} is not available in procedure {self.procedure}"
             )
         m = self.state.all_modules[module_name]
-        return QcdlModule.from_rewrapping(m, new_proc=self.procedure)
+        return QCDLModule.from_rewrapping(m, new_proc=self.procedure)
 
     @classmethod
     def unwrap(cls, container: Set | Sequence | Mapping | None) -> Any:
@@ -1886,10 +1886,10 @@ class QcdlModule(QcdlModuleContainer):
 
         The objects that are replaced are:
 
-        * QcdlModule objects and Systems are converted to their string names
+        * QCDLModule objects and Systems are converted to their string names
           (i.e., "q0", "q3", etc). Their procedure context is encoded elsewhere
           in the json file and does not need to be preserved here.
-        * QcdlArguments are also transformed by their to_dict implementation.
+        * QCDLArguments are also transformed by their to_dict implementation.
         * as a convenience, this method will handle np types
 
         NOTE: This code is used in contexts where the output is not required to be
@@ -1916,7 +1916,7 @@ class QcdlModule(QcdlModuleContainer):
                 obj = []
             elif isinstance(raw_obj, cls):  # This only catches QCDL modules!
                 obj = raw_obj.qcdl_module_name
-            elif isinstance(raw_obj, QcdlArgument):
+            elif isinstance(raw_obj, QCDLArgument):
                 obj = raw_obj.serialize()
             else:
                 obj = raw_obj
@@ -1939,12 +1939,12 @@ class QcdlModule(QcdlModuleContainer):
 
     @classmethod
     def rewrap(cls, args: Any, kwargs: Any, proc: Procedure) -> None:
-        """Create QcdlModule wrappers around modules in provided args/kwargs
+        """Create QCDLModule wrappers around modules in provided args/kwargs
 
-        A QcdlModule is a module wrapped in a Procedure, so when passing a
+        A QCDLModule is a module wrapped in a Procedure, so when passing a
         module into a procedure, each module must be rewrapped with the
         Procedure. This method will recursively scan args/kwargs and replace
-        every QcdlModule with a new QcdlModule (or for a System, reassign proc)
+        every QCDLModule with a new QCDLModule (or for a System, reassign proc)
 
         Args:
             args (Any): container of parameters
@@ -1957,17 +1957,17 @@ class QcdlModule(QcdlModuleContainer):
         def mapper(value: Any) -> Any:
             if isinstance(value, cls):
                 return value.from_rewrapping(value, new_proc=proc)
-            elif isinstance(value, QcdlModuleContainerBase):
+            elif isinstance(value, QCDLModuleContainerBase):
                 value.set_procedure(proc)
             return value
 
         map_container(
             [args, kwargs],
             map_value=mapper,
-            map_value_instance_types=(cls, QcdlModuleContainerBase),
+            map_value_instance_types=(cls, QCDLModuleContainerBase),
         )
 
-    def __getattr__(self, name: str) -> QcdlStatementBridge:
+    def __getattr__(self, name: str) -> QCDLStatementBridge:
         """The __getattr__ implements a mechanism for appending arbitrary
         instructions to the Procedure.
 
@@ -1979,7 +1979,7 @@ class QcdlModule(QcdlModuleContainer):
             name (str): The name of the instruction.
 
         Returns:
-            QcdlStatementBridge: an instance which may be invoked to add args/kwargs to
+            QCDLStatementBridge: an instance which may be invoked to add args/kwargs to
             the invocation.
 
         :meta public:
@@ -1987,21 +1987,21 @@ class QcdlModule(QcdlModuleContainer):
         # NOTE: this does not validate whether the procedure/method exists or not
 
         # At this point, the returned object is expected to be evaluated as a callable
-        # and not actually stored in the qcdl json. A QcdlStatementBridge can help
+        # and not actually stored in the qcdl json. A QCDLStatementBridge can help
         # format an appropriate error message if the user intended to get an element.
-        return QcdlStatementBridge(self._proc, self.qcdl_module_name, name)
+        return QCDLStatementBridge(self._proc, self.qcdl_module_name, name)
 
     def __str__(self) -> str:
-        return "<QcdlModule %s/%s>" % (self.procedure.name, self.qcdl_module_name)
+        return "<QCDLModule %s/%s>" % (self.procedure.name, self.qcdl_module_name)
 
     def __repr__(self) -> str:
         return str(self)
 
 
-class Scope(QcdlModuleContainer):
+class Scope(QCDLModuleContainer):
     """Qubits to be used for quantum operations.
 
-    This subclass of :class:`QcdlModuleContainer` facilitates use of features
+    This subclass of :class:`QCDLModuleContainer` facilitates use of features
     related to real-time control flow.
 
     Args:
@@ -2031,13 +2031,13 @@ class Scope(QcdlModuleContainer):
             qcdl_program = scope_example()
     """
 
-    def __init__(self, *qubits: QcdlModuleContainer, use_scope_id: bool = True):
+    def __init__(self, *qubits: QCDLModuleContainer, use_scope_id: bool = True):
         # Deduplicate by assembling a dict
         qubits_by_name = {
             mod.qcdl_module_name: mod for q in qubits for mod in q.qcdl_modules
         }
 
-        # this needs to be a list so that QcdlModuleContainer can update
+        # this needs to be a list so that QCDLModuleContainer can update
         # qubits when a Scope goes in and out of procedures.
         self._qubits = list(qubits_by_name.values())
 
@@ -2086,13 +2086,13 @@ class Scope(QcdlModuleContainer):
         return self._scope_id
 
     @property
-    def qcdl_modules(self) -> list[QcdlModule]:
-        """list[QcdlModule]: The QCDL modules, typically qubits, in this scope.
+    def qcdl_modules(self) -> list[QCDLModule]:
+        """list[QCDLModule]: The QCDL modules, typically qubits, in this scope.
 
         Examples:
             This example uses the :attr:`~Scope.qcdl_modules` property to add a
             comment in generated QCDL with a qubit's name. In practice, you
-            would likely use the simpler :attr:`~dwave.gate.qcdl.QcdlModule.name`
+            would likely use the simpler :attr:`~dwave.gate.qcdl.QCDLModule.name`
             property (i.e., ``q0.name``)
 
             .. testcode::
@@ -2189,7 +2189,7 @@ def procedure(
         kwargs = dict(kwargs)
 
         # all modules that are passed will go into the procedure
-        # so search all arguments for a QcdlModule, any will do
+        # so search all arguments for a QCDLModule, any will do
         caller = None
 
         # we need to capture the invoking signature to preserve
@@ -2202,7 +2202,7 @@ def procedure(
         def _add_module(m: Any, _caller: Any, update_op_key: bool = True) -> Any:
             # modifies sig_modules and op_key from outer scope
             # _caller used to set caller in outer scope
-            if isinstance(m, QcdlModuleContainerBase) and not isinstance(m, QcdlModule):
+            if isinstance(m, QCDLModuleContainerBase) and not isinstance(m, QCDLModule):
                 container_op_key = m.op_key  # type: ignore[attr-defined]
                 for q in m.qcdl_modules:
                     _caller = _add_module(
@@ -2235,14 +2235,14 @@ def procedure(
         else:
             wrap_args = args
 
-        # recursively find all QcdlModules and Systems
+        # recursively find all QCDLModules and Systems
         # add them in the order they appear
         for path, a in objwalk([wrap_args, kwargs]):
             if isinstance(a, (FixedPointRegister, Register)):
                 # we want the name of the register in the procedure name
                 op_key.append(str(a))
                 caller = _add_module(a, caller)
-            elif isinstance(a, (QcdlModule, QcdlModuleContainerBase)):
+            elif isinstance(a, (QCDLModule, QCDLModuleContainerBase)):
                 if path[0] == 1:
                     # if it was passed as a kwarg, then include the name of the
                     # kwarg
@@ -2299,10 +2299,10 @@ def procedure(
                 kwargs=kwargs,
                 qcdl_operator=op_name,
             )
-            QcdlModule.rewrap(wrap_args, kwargs, p)
+            QCDLModule.rewrap(wrap_args, kwargs, p)
 
             # NOTE: we can't prevent f from changing args or kwargs. If f drops
-            # a QcdlModule from args/kwargs, then rewrapping it will need to
+            # a QCDLModule from args/kwargs, then rewrapping it will need to
             # happen some other way if necessary
             rtrn = f(*args, **kwargs)
 
@@ -2316,14 +2316,14 @@ def procedure(
 
         if call_method:
             # Reset modules to prior procedure
-            QcdlModule.rewrap(wrap_args, kwargs, caller)
+            QCDLModule.rewrap(wrap_args, kwargs, caller)
 
             # in case f altered args or kwargs by dropping modules, reset the
             # modules we collected too since modules doesn't have the
             # args/kwargs structure, the alterations here are in-place (see
             # rewrap) (rewrapping an object twice with the same caller isn't a
             # problem)
-            QcdlModule.rewrap(modules, {}, caller)
+            QCDLModule.rewrap(modules, {}, caller)
 
         return rtrn
 

--- a/dwave/gate/qcdl/implementations.py
+++ b/dwave/gate/qcdl/implementations.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .components import QcdlModule, Scope, procedure
+from .components import QCDLModule, Scope, procedure
 from .constants import LogicalOutcomeToInteger
 
 if TYPE_CHECKING:
@@ -26,10 +26,10 @@ if TYPE_CHECKING:
 
 
 def _get_receivers(
-    sender: QcdlModule,
+    sender: QCDLModule,
     register: Register,
-    receivers: list[QcdlModule] | None = None,
-) -> list[QcdlModule]:
+    receivers: list[QCDLModule] | None = None,
+) -> list[QCDLModule]:
     if receivers is None:
         receivers = [q for q in register.qcdl_modules if repr(q) != repr(sender)]
     else:
@@ -40,9 +40,9 @@ def _get_receivers(
 
 @procedure
 def mirror_bool_register(
-    sender: QcdlModule,
+    sender: QCDLModule,
     register: Register,
-    receivers: list[QcdlModule] | None = None,
+    receivers: list[QCDLModule] | None = None,
 ) -> None:
     """Mirror a Boolean register to registers associated with other qubits.
 
@@ -102,9 +102,9 @@ def mirror_bool_register(
 
 @procedure
 def mirror_measurement_register(
-    sender: QcdlModule,
+    sender: QCDLModule,
     register: Register,
-    receivers: list[QcdlModule] | None = None,
+    receivers: list[QCDLModule] | None = None,
 ) -> None:
     """Mirror a two-bit qubit measurement to registers associated with other
     qubits.

--- a/dwave/gate/qcdl/operations.py
+++ b/dwave/gate/qcdl/operations.py
@@ -61,7 +61,7 @@ from typing import Any, TypeAlias
 import numpy as np
 
 from . import implementations
-from .components import QcdlModule
+from .components import QCDLModule
 from .exceptions import QCDLUserError
 from .registers import FixedPointRegister, Register
 
@@ -70,7 +70,7 @@ AngleType: TypeAlias = float | FixedPointRegister
 # Operations
 
 
-def initialize(*qubits: QcdlModule) -> None:
+def initialize(*qubits: QCDLModule) -> None:
     """Initialize qubits.
 
     This function has non-deterministic duration because the implementation is
@@ -81,14 +81,14 @@ def initialize(*qubits: QcdlModule) -> None:
         all programs.
 
     Args:
-        *qubits (QcdlModule): Qubits to initialize. It is not an error to do
+        *qubits (QCDLModule): Qubits to initialize. It is not an error to do
             so, but unused qubits should not be included.
 
     """
     qubits[0].initialize(*qubits[1:])
 
 
-def barrier(*qubits: QcdlModule, label: str | None = None) -> None:
+def barrier(*qubits: QCDLModule, label: str | None = None) -> None:
     """Place a barrier on qubits.
 
     The transpiler does not combine gates across a barrier. This is a directive
@@ -96,11 +96,11 @@ def barrier(*qubits: QcdlModule, label: str | None = None) -> None:
     like a comment.
 
     .. note:: This operation is different from a
-        :meth:`~dwave.gate.qcdl.QcdlModuleContainer.sync` method, which is used
+        :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` method, which is used
         to control the order that the compiler schedules operations.
 
     Args:
-        *qubits (QcdlModule): The qubits to put a barrier on.
+        *qubits (QCDLModule): The qubits to put a barrier on.
         label (str, optional): An annotation.
 
     Examples:
@@ -141,7 +141,7 @@ def barrier(*qubits: QcdlModule, label: str | None = None) -> None:
 
 
 def measure(
-    qubit: QcdlModule,
+    qubit: QCDLModule,
     log: bool = True,
     tag: str | None = None,
     register: Register | None = None,
@@ -150,7 +150,7 @@ def measure(
     """Measure a qubit.
 
     Args:
-        qubit (QcdlModule): The qubit to measure.
+        qubit (QCDLModule): The qubit to measure.
         log (bool, optional): If True, the measurement result is logged, meaning
             it is included in the returned array for this qubit.
         tag (str | None, optional): Name for this measurement, used to organize the
@@ -196,11 +196,11 @@ def measure(
         implementations.mirror_measurement_register(sender=qubit, register=register)
 
 
-def mced(qubit: QcdlModule, register: Register, mirror: bool = True) -> None:
+def mced(qubit: QCDLModule, register: Register, mirror: bool = True) -> None:
     """Perform a non-destructive mid-circuit erasure detection (MCED).
 
     Args:
-        qubit (QcdlModule): The qubit to inspect.
+        qubit (QCDLModule): The qubit to inspect.
         register (Register): Register used for storing the outcome. Supported
             outcomes are:
 
@@ -236,7 +236,7 @@ def mced(qubit: QcdlModule, register: Register, mirror: bool = True) -> None:
 # 1 Qubit Non-Parameterized Gates
 
 
-def x(qubit: QcdlModule) -> None:
+def x(qubit: QCDLModule) -> None:
     """`X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.XGate>`_
     gate.
 
@@ -260,7 +260,7 @@ def x(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "x", [qubit], None)
 
 
-def sx(qubit: QcdlModule) -> None:
+def sx(qubit: QCDLModule) -> None:
     r"""`Square-root of X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SXGate>`_
     (:math:`\sqrt X`) gate.
 
@@ -284,7 +284,7 @@ def sx(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "sx", [qubit], None)
 
 
-def y(qubit: QcdlModule) -> None:
+def y(qubit: QCDLModule) -> None:
     """`Y <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.YGate>`_
     gate.
 
@@ -308,7 +308,7 @@ def y(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "y", [qubit], None)
 
 
-def sy(qubit: QcdlModule) -> None:
+def sy(qubit: QCDLModule) -> None:
     r"""SQRT of Y gate.
     TODO it's not a qiskit gate
 
@@ -332,7 +332,7 @@ def sy(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, np.pi / 2], None)
 
 
-def sydg(qubit: QcdlModule) -> None:
+def sydg(qubit: QCDLModule) -> None:
     r"""SQRT of Y_adjoint gate.
     TODO it's not a qiskit gate
 
@@ -356,7 +356,7 @@ def sydg(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, -np.pi / 2], None)
 
 
-def z(qubit: QcdlModule) -> None:
+def z(qubit: QCDLModule) -> None:
     """`Z <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.ZGate>`_
     gate.
 
@@ -380,7 +380,7 @@ def z(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "z", [qubit], None)
 
 
-def s(qubit: QcdlModule) -> None:
+def s(qubit: QCDLModule) -> None:
     """`S <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SGate>`_
     gate.
 
@@ -404,7 +404,7 @@ def s(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "s", [qubit], None)
 
 
-def sdg(qubit: QcdlModule) -> None:
+def sdg(qubit: QCDLModule) -> None:
     r"""`S-adjoint <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SdgGate>`_
     (:math:`S^\dagger`) gate.
 
@@ -429,7 +429,7 @@ def sdg(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "sdg", [qubit], None)
 
 
-def t(qubit: QcdlModule) -> None:
+def t(qubit: QCDLModule) -> None:
     r"""`T <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.TGate>`_
     (:math:`\sqrt[4]{Z}`) gate.
 
@@ -453,7 +453,7 @@ def t(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "t", [qubit], None)
 
 
-def tdg(qubit: QcdlModule) -> None:
+def tdg(qubit: QCDLModule) -> None:
     r"""`T-adjoint <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.TdgGate>`_
     (:math:`T^\dagger`) gate.
 
@@ -477,7 +477,7 @@ def tdg(qubit: QcdlModule) -> None:
     qubit.procedure.add_statement(None, "tdg", [qubit], None)
 
 
-def h(qubit: QcdlModule) -> None:
+def h(qubit: QCDLModule) -> None:
     """`Hadamard <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.HGate>`_
     gate.
 
@@ -504,7 +504,7 @@ def h(qubit: QcdlModule) -> None:
 # 1 Qubit Parameterized Gates
 
 
-def rx(qubit: QcdlModule, phi: AngleType) -> None:
+def rx(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `X-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RXGate>`_
     gate.
@@ -531,7 +531,7 @@ def rx(qubit: QcdlModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "rx", [qubit, phi], None)
 
 
-def ry(qubit: QcdlModule, phi: AngleType) -> None:
+def ry(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `Y-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RYGate>`_
     gate.
@@ -558,7 +558,7 @@ def ry(qubit: QcdlModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, phi], None)
 
 
-def rz(qubit: QcdlModule, phi: AngleType) -> None:
+def rz(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `Z-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RZGate>`_
     gate.
@@ -585,7 +585,7 @@ def rz(qubit: QcdlModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "rz", [qubit, phi], None)
 
 
-def p(qubit: QcdlModule, theta: AngleType) -> None:
+def p(qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Phase <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.PhaseGate>`_
     gate.
 
@@ -611,7 +611,7 @@ def p(qubit: QcdlModule, theta: AngleType) -> None:
     qubit.procedure.add_statement(None, "p", [qubit, theta], None)
 
 
-def u(qubit: QcdlModule, theta: AngleType, phi: AngleType, lam: AngleType) -> None:
+def u(qubit: QCDLModule, theta: AngleType, phi: AngleType, lam: AngleType) -> None:
     r"""Single-qubit
     `generic U <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.UGate>`_
     gate.
@@ -642,7 +642,7 @@ def u(qubit: QcdlModule, theta: AngleType, phi: AngleType, lam: AngleType) -> No
 # 2 Qubit Non-Parameterized Gates
 
 
-def swap(qubit1: QcdlModule, qubit2: QcdlModule) -> None:
+def swap(qubit1: QCDLModule, qubit2: QCDLModule) -> None:
     """`Swap <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SwapGate>`_
     gate.
 
@@ -670,7 +670,7 @@ def swap(qubit1: QcdlModule, qubit2: QcdlModule) -> None:
     qubit1.procedure.add_statement(None, "swap", [qubit1, qubit2], None)
 
 
-def cx(control_qubit: QcdlModule, target_qubit: QcdlModule) -> None:
+def cx(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CXGate>`_
     gate.
 
@@ -698,7 +698,7 @@ def cx(control_qubit: QcdlModule, target_qubit: QcdlModule) -> None:
     )
 
 
-def cy(control_qubit: QcdlModule, target_qubit: QcdlModule) -> None:
+def cy(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-Y <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CYGate>`_
     gate.
 
@@ -726,7 +726,7 @@ def cy(control_qubit: QcdlModule, target_qubit: QcdlModule) -> None:
     )
 
 
-def cz(control_qubit: QcdlModule, target_qubit: QcdlModule) -> None:
+def cz(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-Z <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CZGate>`_
     gate.
 
@@ -757,7 +757,7 @@ def cz(control_qubit: QcdlModule, target_qubit: QcdlModule) -> None:
 # 2 Qubit Parameterized Gates
 
 
-def crx(control_qubit: QcdlModule, target_qubit: QcdlModule, theta: AngleType) -> None:
+def crx(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RX <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRXGate>`_
     gate.
 
@@ -787,7 +787,7 @@ def crx(control_qubit: QcdlModule, target_qubit: QcdlModule, theta: AngleType) -
     )
 
 
-def cry(control_qubit: QcdlModule, target_qubit: QcdlModule, theta: AngleType) -> None:
+def cry(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RY <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRYGate>`_
     gate.
 
@@ -817,7 +817,7 @@ def cry(control_qubit: QcdlModule, target_qubit: QcdlModule, theta: AngleType) -
     )
 
 
-def crz(control_qubit: QcdlModule, target_qubit: QcdlModule, theta: AngleType) -> None:
+def crz(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RZ <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRZGate>`_
     gate.
 
@@ -847,7 +847,7 @@ def crz(control_qubit: QcdlModule, target_qubit: QcdlModule, theta: AngleType) -
     )
 
 
-def cp(control_qubit: QcdlModule, target_qubit: QcdlModule, theta: AngleType) -> None:
+def cp(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-Phase <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CPhaseGate>`_
     gate.
 
@@ -878,8 +878,8 @@ def cp(control_qubit: QcdlModule, target_qubit: QcdlModule, theta: AngleType) ->
 
 
 def cu(
-    control_qubit: QcdlModule,
-    target_qubit: QcdlModule,
+    control_qubit: QCDLModule,
+    target_qubit: QCDLModule,
     theta: AngleType,
     phi: AngleType,
     lam: AngleType,
@@ -919,7 +919,7 @@ def cu(
     )
 
 
-def rxx(qubit1: QcdlModule, qubit2: QcdlModule, theta: AngleType) -> None:
+def rxx(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `XX-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RXXGate>`_
     gate.
@@ -947,7 +947,7 @@ def rxx(qubit1: QcdlModule, qubit2: QcdlModule, theta: AngleType) -> None:
     qubit1.procedure.add_statement(None, "rxx", [qubit1, qubit2, theta], None)
 
 
-def ryy(qubit1: QcdlModule, qubit2: QcdlModule, theta: AngleType) -> None:
+def ryy(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `YY-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RYYGate>`_
     gate.
@@ -975,7 +975,7 @@ def ryy(qubit1: QcdlModule, qubit2: QcdlModule, theta: AngleType) -> None:
     qubit1.procedure.add_statement(None, "ryy", [qubit1, qubit2, theta], None)
 
 
-def rzz(qubit1: QcdlModule, qubit2: QcdlModule, theta: AngleType) -> None:
+def rzz(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `ZZ-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RZZGate>`_
     gate.

--- a/dwave/gate/qcdl/qcdl_circuit.py
+++ b/dwave/gate/qcdl/qcdl_circuit.py
@@ -26,9 +26,9 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias, overload
 import numpy as np
 
 from .base import IndexerMixin
-from .components import Procedure, QcdlModule
+from .components import Procedure, QCDLModule
 from .exceptions import QCDLInternalError, QCDLUserError
-from .qcdl_models import Qcdl, QcdlModuleName, QcdlProcedureDef
+from .qcdl_models import QCDLProgram, QCDLModuleName, QCDLProcedureDef
 from .transformer import print_qcdl
 from .utils import is_qubit_or_coupler_name
 
@@ -41,18 +41,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class QcdlCircuit(IndexerMixin):
+class QCDLCircuit(IndexerMixin):
     """The circuit coordinates/stores data across the qubits/procedures and
     prepares the data structure for transmission to the compiler.
 
     A simple use case would be:
 
-        qcdl = QcdlCircuit(environment)
+        qcdl = QCDLCircuit(environment)
 
         # create the objects used for invoking statements
         qmods = qcdl.initialize_modules()
 
-        # call whatever instructions on those QcdlModules
+        # call whatever instructions on those QCDLModules
         qmods["q0"].x()
         qmods["q0"].measure()
 
@@ -91,7 +91,7 @@ class QcdlCircuit(IndexerMixin):
         """
         super().__init__(next_indices=next_indices)
         self._environment = environment
-        self._all_modules: dict[str, QcdlModule] | None = None
+        self._all_modules: dict[str, QCDLModule] | None = None
 
         self._output_pools: dict[str, dict[str, list[str]]] = defaultdict(
             lambda: dict(
@@ -100,8 +100,8 @@ class QcdlCircuit(IndexerMixin):
         )
 
         self._main: Procedure | None = None
-        self._program: QcdlProcedureDef | None = None
-        self._procedures: dict[str, QcdlProcedureDef] = {}
+        self._program: QCDLProcedureDef | None = None
+        self._procedures: dict[str, QCDLProcedureDef] = {}
         self._validate_non_deterministic_qubits_mid = (
             validate_non_deterministic_qubits_mid
         )
@@ -121,7 +121,7 @@ class QcdlCircuit(IndexerMixin):
     def environment(self) -> Environment:
         if self._environment is None:
             raise QCDLUserError(
-                "This QcdlCircuit was not initialized with an environment"
+                "This QCDLCircuit was not initialized with an environment"
             )
 
         return self._environment
@@ -135,8 +135,8 @@ class QcdlCircuit(IndexerMixin):
         main_name: str = "main",
         modules: Sequence[Module] | None = None,
         **kwargs: Any,
-    ) -> dict[str, QcdlModule]:
-        """Initialize a dict of QcdlModules
+    ) -> dict[str, QCDLModule]:
+        """Initialize a dict of QCDLModules
 
         Args:
             main_name (str, optional): Name for the main procedure.
@@ -148,7 +148,7 @@ class QcdlCircuit(IndexerMixin):
             QCDLUserError: can only do this once
 
         Returns:
-            dict[str, QcdlModule]: dictionary of QcdlModules
+            dict[str, QCDLModule]: dictionary of QCDLModules
         """
 
         if self._main:
@@ -162,7 +162,7 @@ class QcdlCircuit(IndexerMixin):
 
         p = Procedure(main_name, state=self, **kwargs)
 
-        all_mods = {m.name: QcdlModule(m.name, p) for m in modules}
+        all_mods = {m.name: QCDLModule(m.name, p) for m in modules}
         self.all_modules = all_mods
         self._main = p
         return all_mods
@@ -174,28 +174,28 @@ class QcdlCircuit(IndexerMixin):
         return self._main
 
     @property
-    def all_modules(self) -> dict[str, QcdlModule] | None:
-        """A dict of all the QcdlModules in the system
+    def all_modules(self) -> dict[str, QCDLModule] | None:
+        """A dict of all the QCDLModules in the system
 
         These objects are not necessarily ready to be used in a circuit as-is,
         they probably need to be rewrapped based on the procedure, so clients
         should use `get_other_qcdl_module` instead of accessing this directly.
 
         Returns:
-            dict[str, QcdlModule] | None: QcdlModule objects
+            dict[str, QCDLModule] | None: QCDLModule objects
         """
         return self._all_modules
 
     @all_modules.setter
-    def all_modules(self, all_modules: dict[str, QcdlModule]) -> None:
-        """This setter should only be called after all QcdlModules are instantiated
+    def all_modules(self, all_modules: dict[str, QCDLModule]) -> None:
+        """This setter should only be called after all QCDLModules are instantiated
         (so that all may be provided together)
         """
         self._all_modules = all_modules
 
     def get_or_add_arbitrary_function(
         self,
-        qubit: QcdlModule,
+        qubit: QCDLModule,
         tag: Any,
         foo: Any,
         dtype: Any,
@@ -220,7 +220,7 @@ class QcdlCircuit(IndexerMixin):
         is only used by the arbitrary_function decorator.
 
         Args:
-            qubit (QcdlModule): the location this arbfn should be stored
+            qubit (QCDLModule): the location this arbfn should be stored
             tag (str): Name of the arbitrary function
             foo (callable or list): The mechanism for generating the table
             dtype (int or float): The data type of the output.
@@ -228,7 +228,7 @@ class QcdlCircuit(IndexerMixin):
             validate (bool): Validate the data for range. It would be reasonable
                to skip this if you won't use this function in the invalid intervals of
                the domain.
-            qubits (QcdlModule, optional): other qubits to add this arbfn
+            qubits (QCDLModule, optional): other qubits to add this arbfn
 
         Raises:
             QCDLUserError: only a max of 8 arbitrary functions are allowed
@@ -306,7 +306,7 @@ class QcdlCircuit(IndexerMixin):
         arbfns[tag] = True
 
     def available_outputs(
-        self, qubits: QcdlModule | Sequence[QcdlModule], category: str
+        self, qubits: QCDLModule | Sequence[QCDLModule], category: str
     ) -> set[str] | None:
         """Which outputs are available for a qubit (or list of qubits)
 
@@ -314,7 +314,7 @@ class QcdlCircuit(IndexerMixin):
         all qubits.
 
         Args:
-            qubits (QcdlModule or list[QcdlModule]): spaces to search
+            qubits (QCDLModule or list[QCDLModule]): spaces to search
             category (str): DYN or GOF
 
         Raises:
@@ -340,7 +340,7 @@ class QcdlCircuit(IndexerMixin):
         return intersection_available
 
     def reserve_output(
-        self, qubit: QcdlModule, category: str | None = None, name: str | None = None
+        self, qubit: QCDLModule, category: str | None = None, name: str | None = None
     ) -> str | None:
         """Reserve an output (DYN or GOF)
 
@@ -351,7 +351,7 @@ class QcdlCircuit(IndexerMixin):
         same output at the same time. Only 3 DYN and 4 GOF are available.
 
         Args:
-            qubit (QcdlModule): where to reserve it
+            qubit (QCDLModule): where to reserve it
             category (str): DYN or GOF
             name (str): reserve a specific output
 
@@ -387,11 +387,11 @@ class QcdlCircuit(IndexerMixin):
         else:
             return pool.pop()
 
-    def release_output(self, qubit: QcdlModule, output: str) -> None:
+    def release_output(self, qubit: QCDLModule, output: str) -> None:
         """Release an output back to the pool
 
         Args:
-            qubit (QcdlModule): where the output came from
+            qubit (QCDLModule): where the output came from
             output (str): the DYNi or GOFi to return
 
         Raises:
@@ -412,7 +412,7 @@ class QcdlCircuit(IndexerMixin):
 
     def set_or_check_nondeterministic_modules(
         self,
-        modules: Iterable[str | QcdlModule | QcdlModuleName],
+        modules: Iterable[str | QCDLModule | QCDLModuleName],
         validate: bool = True,
         description: str | None = None,
     ) -> None:
@@ -442,7 +442,7 @@ class QcdlCircuit(IndexerMixin):
                     m
                     if isinstance(m, str)
                     else (
-                        m.name if isinstance(m, QcdlModuleName) else m.qcdl_module_name
+                        m.name if isinstance(m, QCDLModuleName) else m.qcdl_module_name
                     )
                 )
                 for m in modules
@@ -467,10 +467,10 @@ class QcdlCircuit(IndexerMixin):
                 logger.error(msg)
 
     @property
-    def procedures(self) -> dict[str, QcdlProcedureDef]:
+    def procedures(self) -> dict[str, QCDLProcedureDef]:
         return self._procedures
 
-    def get_procedure(self, procedure_name: str) -> QcdlProcedureDef | None:
+    def get_procedure(self, procedure_name: str) -> QCDLProcedureDef | None:
         return self.procedures.get(procedure_name)
 
     def register_procedure(self, procedure: Procedure) -> None:
@@ -497,11 +497,11 @@ class QcdlCircuit(IndexerMixin):
                 )
         self.procedures[procedure.proc_name] = cur_def
 
-    def to_model(self) -> Qcdl:
+    def to_model(self) -> QCDLProgram:
         """Build and return the validated QCDL model for this circuit.
 
         Returns:
-            Qcdl: the validated program model, ready to pass to a
+            QCDLProgram: the validated program model, ready to pass to a
                 compiler or convert to a plain dict via
                 ``model.model_dump(exclude_unset=True)``.
         """
@@ -515,7 +515,7 @@ class QcdlCircuit(IndexerMixin):
             description="in qubits used in circuit",
         )
 
-        return Qcdl(
+        return QCDLProgram(
             program=self._program,
             procedures=self.procedures,
             next_indices=dict(self._next_indices),
@@ -535,7 +535,7 @@ def _get_fspec(f: Any) -> tuple[list[str], str | None]:
     return fspec.args, f_keywords
 
 
-QcdlV2: TypeAlias = str
+QCDLV2: TypeAlias = str
 """Display-oriented QCDL string representation returned by @qcdl when
 ``to_qcdlv2=True``.
 
@@ -543,14 +543,14 @@ This form is intended primarily for visualization, debugging, or compatibility
 with older QCDL tooling.
 """
 
-QcdlSource: TypeAlias = Callable[..., None]
+QCDLSource: TypeAlias = Callable[..., None]
 """Type of an undecorated QCDL builder function consumed by @qcdl.
 
 The signature is intentionally broad because @qcdl injects qubit/module
 arguments at runtime.
 """
 
-QcdlFunc: TypeAlias = Callable[..., Qcdl]
+QCDLFunc: TypeAlias = Callable[..., QCDLProgram]
 """Decorated callable returned by ``@qcdl`` when producing a payload.
 
 The resulting function may accept ordinary user parameters, while qubit or
@@ -558,7 +558,7 @@ module parameters are supplied by the decorator machinery. Calling it returns a
 structured QCDL payload.
 """
 
-QcdlFuncV2: TypeAlias = Callable[..., QcdlV2]
+QCDLFuncV2: TypeAlias = Callable[..., QCDLV2]
 """Decorated callable returned by ``@qcdl`` when producing a v2 display form.
 
 This variant is mainly useful for inspection or rendering of QCDL in an older
@@ -576,7 +576,7 @@ def qcdl(
     to_qcdlv2: Literal[False] = False,
     validate_non_deterministic_qubits_mid: bool = True,
     validate_non_deterministic_qubits_end: bool = True,
-) -> Callable[[QcdlSource], QcdlFunc]: ...
+) -> Callable[[QCDLSource], QCDLFunc]: ...
 
 
 @overload
@@ -588,7 +588,7 @@ def qcdl(
     to_qcdlv2: Literal[True] = True,
     validate_non_deterministic_qubits_mid: bool = True,
     validate_non_deterministic_qubits_end: bool = True,
-) -> Callable[[QcdlSource], QcdlFuncV2]: ...
+) -> Callable[[QCDLSource], QCDLFuncV2]: ...
 
 
 def qcdl(
@@ -599,7 +599,7 @@ def qcdl(
     to_qcdlv2: bool = False,
     validate_non_deterministic_qubits_mid: bool = True,
     validate_non_deterministic_qubits_end: bool = True,
-) -> Callable[[QcdlSource], Callable[..., Qcdl | QcdlV2]]:
+) -> Callable[[QCDLSource], Callable[..., QCDLProgram | QCDLV2]]:
     """Decorator to construct a :ref:`QCDL <qcdl_programming_basic>` program.
 
     The decorated function returns a
@@ -617,7 +617,7 @@ def qcdl(
             supported by the environment. This parameter is intended for use by
             developers of QCDL.
         machine: If a machine is provided, the machine supplies system instances
-            instead of the :class:`~dwave.gate.qcdl.QcdlModule` instance. This
+            instead of the :class:`~dwave.gate.qcdl.QCDLModule` instance. This
             parameter is intended for use by developers of QCDL.
         next_indices: Values from which to start the circuit's indices. This
             facilitates uniqueness across compiler "visitors".
@@ -668,9 +668,9 @@ def qcdl(
 
     """
 
-    def decorator(f: QcdlSource) -> Callable[..., Qcdl | QcdlV2]:
+    def decorator(f: QCDLSource) -> Callable[..., QCDLProgram | QCDLV2]:
         @functools.wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> Qcdl | QcdlV2:
+        def wrapper(*args: Any, **kwargs: Any) -> QCDLProgram | QCDLV2:
             if machine and environment:
                 raise QCDLUserError("may not provide both machine and environment")
 
@@ -681,7 +681,7 @@ def qcdl(
                 # outer scope
                 _env = environment
 
-            qcdl_circuit = QcdlCircuit(
+            qcdl_circuit = QCDLCircuit(
                 environment=_env,
                 next_indices=next_indices,
                 validate_non_deterministic_qubits_mid=validate_non_deterministic_qubits_mid,

--- a/dwave/gate/qcdl/qcdl_models.py
+++ b/dwave/gate/qcdl/qcdl_models.py
@@ -18,14 +18,14 @@ This module provides Pydantic-based models for validating, documenting, and
 serializing QCDL payloads.  The models add runtime validation, field-level
 documentation, and structured serialization/deserialization.
 
-:class:`QcdlStatement` also surfaces a full derived API
+:class:`QCDLStatement` also surfaces a full derived API
 (``modules``, ``qargs``, ``condition``, ``simple_desc``, etc.) directly
 on the model for statement-level logic.
 
 Round-tripping
 --------------
 
-:meth:`QcdlCircuit.to_model()` returns a :class:`Qcdl` directly.
+:meth:`QCDLCircuit.to_model()` returns a :class:`QCDLProgram` directly.
 To recover a plain :class:`dict` for transmission to the compiler::
 
     payload = model.model_dump()
@@ -35,7 +35,7 @@ Statement dict sparsity
 
 :meth:`Procedure.add_statement` only stores ``args``, ``kwargs``, and
 ``qubits`` in the statement dict when they are non-empty.  Use
-``model_dump(exclude_unset=True)`` on a :class:`QcdlStatement` to
+``model_dump(exclude_unset=True)`` on a :class:`QCDLStatement` to
 recover the same sparse representation::
 
     sparse = stmt_model.model_dump(exclude_unset=True)
@@ -70,7 +70,7 @@ def _get_module_from_arg(arg: Any) -> str | None:
     return None
 
 
-class QcdlModuleName(BaseModel):
+class QCDLModuleName(BaseModel):
     """A concrete qubit, coupler, or arbitrary-prefix module referenced in a
     QCDL statement.
 
@@ -91,14 +91,14 @@ class QcdlModuleName(BaseModel):
 
     Examples
     --------
-    >>> QcdlModuleName.model_validate("q2")
-    QcdlModuleName('q2')
-    >>> QcdlModuleName(kind="coupler", index=5).name
+    >>> QCDLModuleName.model_validate("q2")
+    QCDLModuleName('q2')
+    >>> QCDLModuleName(kind="coupler", index=5).name
     'c5'
-    >>> QcdlModuleName.model_validate("m0")
-    QcdlModuleName('m0')
-    >>> QcdlModuleName.model_validate("m")
-    QcdlModuleName('m')
+    >>> QCDLModuleName.model_validate("m0")
+    QCDLModuleName('m0')
+    >>> QCDLModuleName.model_validate("m")
+    QCDLModuleName('m')
     """
 
     model_config = ConfigDict(frozen=True)
@@ -127,7 +127,7 @@ class QcdlModuleName(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def _validate_kind(self) -> QcdlModuleName:
+    def _validate_kind(self) -> QCDLModuleName:
         if not self.kind.isidentifier():
             raise ValueError(f"kind {self.kind!r} is not a valid identifier")
         return self
@@ -165,10 +165,10 @@ class QcdlModuleName(BaseModel):
         return self.name
 
     def __repr__(self) -> str:
-        return f"QcdlModuleName({self.name!r})"
+        return f"QCDLModuleName({self.name!r})"
 
     def __eq__(self, other: object) -> bool:
-        if isinstance(other, QcdlModuleName):
+        if isinstance(other, QCDLModuleName):
             return self.kind == other.kind and self.index == other.index
         if isinstance(other, str):
             return self.name == other
@@ -178,7 +178,7 @@ class QcdlModuleName(BaseModel):
         return hash(self.name)
 
 
-class QcdlStatement(BaseModel):
+class QCDLStatement(BaseModel):
     """Pydantic model for a single QCDL statement.
 
     Every declared field is optional (defaults are provided for all fields).
@@ -235,7 +235,7 @@ class QcdlStatement(BaseModel):
             raise ValueError(f"op {v!r} is not a valid identifier")
         return v
 
-    qubit: QcdlModuleName | None = Field(
+    qubit: QCDLModuleName | None = Field(
         default=None,
         description=(
             "To give the appearance of the operation being invoked on an"
@@ -251,7 +251,7 @@ class QcdlStatement(BaseModel):
         default_factory=dict,
         description="Keyword arguments to the operation (raw serialization field).",
     )
-    caller_qubits: list[QcdlModuleName] = Field(
+    caller_qubits: list[QCDLModuleName] = Field(
         default_factory=list,
         description=(
             "For procedure-call statements, the qubits passed to the called"
@@ -279,7 +279,7 @@ class QcdlStatement(BaseModel):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def qubits(self) -> list[QcdlModuleName]:
+    def qubits(self) -> list[QCDLModuleName]:
         """All modules (qubits and couplers) referenced by this statement.
 
         Derived from every source in insertion order, without duplicates:
@@ -292,10 +292,10 @@ class QcdlStatement(BaseModel):
         mutations via :meth:`reassign_arg` / :meth:`reassign_kwarg` are
         reflected immediately.
         """
-        _modules: list[QcdlModuleName] = []
+        _modules: list[QCDLModuleName] = []
 
-        def _add(q: str | QcdlModuleName) -> None:
-            m = q if isinstance(q, QcdlModuleName) else QcdlModuleName.model_validate(q)
+        def _add(q: str | QCDLModuleName) -> None:
+            m = q if isinstance(q, QCDLModuleName) else QCDLModuleName.model_validate(q)
             if m not in _modules:
                 _modules.append(m)
 
@@ -342,7 +342,7 @@ class QcdlStatement(BaseModel):
         return self.qubit is None
 
     @property
-    def modules(self) -> list[QcdlModuleName]:
+    def modules(self) -> list[QCDLModuleName]:
         """All modules referenced by this statement.
 
         Alias for :attr:`qubits`.  See that attribute for the derivation
@@ -359,7 +359,7 @@ class QcdlStatement(BaseModel):
     def qubit_names(self) -> list[str]:
         """Names of all qubits referenced by this statement, from all sources.
 
-        Unlike :attr:`qubits`, which returns :class:`QcdlModuleName` objects
+        Unlike :attr:`qubits`, which returns :class:`QCDLModuleName` objects
         for all modules (including couplers), this property returns plain
         string names for qubit modules only.
 
@@ -463,7 +463,7 @@ class QcdlStatement(BaseModel):
         ).strip()
 
 
-class QcdlSignature(BaseModel):
+class QCDLSignature(BaseModel):
     """Pydantic model for a procedure signature.
 
     All fields are required.  ``extra="forbid"`` rejects unrecognized
@@ -475,7 +475,7 @@ class QcdlSignature(BaseModel):
     qcdl_operator: str | None = Field(
         description=(
             "A non-unique human-readable name for a procedure.  Because"
-            " procedure names must be globally unique within a :class:`Qcdl`"
+            " procedure names must be globally unique within a :class:`QCDLProgram`"
             " payload, ``qcdl_operator`` provides a stable label that"
             " multiple distinct procedures may share.  For example, every"
             " ``cz`` implementation on each qubit pair will have a unique"
@@ -484,10 +484,10 @@ class QcdlSignature(BaseModel):
             " logically implements."
         ),
     )
-    qubits: list[QcdlModuleName] = Field(
+    qubits: list[QCDLModuleName] = Field(
         description="Qubits declared in the procedure specification.",
     )
-    qubits_used: list[QcdlModuleName] = Field(
+    qubits_used: list[QCDLModuleName] = Field(
         description=(
             "Qubits the procedure actually touches after transpilation."
             "  This may include more entries than ``qubits`` when the"
@@ -502,18 +502,18 @@ class QcdlSignature(BaseModel):
     )
 
 
-class QcdlProcedureDef(BaseModel):
+class QCDLProcedureDef(BaseModel):
     """Pydantic model for a compiled procedure definition.
 
-    Nesting :class:`QcdlStatement` and :class:`QcdlSignature`
+    Nesting :class:`QCDLStatement` and :class:`QCDLSignature`
     means that calling
-    ``QcdlProcedureDef.model_validate(proc_dict)`` recursively
+    ``QCDLProcedureDef.model_validate(proc_dict)`` recursively
     validates the entire sub-tree.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    statements: list[QcdlStatement] = Field(
+    statements: list[QCDLStatement] = Field(
         description="The ordered sequence of statements that make up this procedure.",
     )
     statement_hash: str | None = Field(
@@ -521,20 +521,20 @@ class QcdlProcedureDef(BaseModel):
         exclude=True,
         description=(
             "SHA-based fingerprint of all statements.  Used by"
-            " ``QcdlCircuit.register_procedure`` to detect whether a"
+            " ``QCDLCircuit.register_procedure`` to detect whether a"
             " procedure is being re-registered with a different body, which"
             " is an error.  Excluded from serialized output."
         ),
     )
-    signature: QcdlSignature = Field(
+    signature: QCDLSignature = Field(
         description="Qubit and argument specification for calling this procedure.",
     )
 
 
-class Qcdl(BaseModel):
+class QCDLProgram(BaseModel):
     """Pydantic model for the top-level QCDL compiler payload.
 
-    :meth:`QcdlCircuit.to_model()` returns an instance of this class directly.
+    :meth:`QCDLCircuit.to_model()` returns an instance of this class directly.
     Use :meth:`model_dump` to recover a plain :class:`dict` suitable for the
     compiler.
 
@@ -544,10 +544,10 @@ class Qcdl(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    program: QcdlProcedureDef = Field(
+    program: QCDLProcedureDef = Field(
         description="The main entry point of the program.",
     )
-    procedures: dict[str, QcdlProcedureDef] = Field(
+    procedures: dict[str, QCDLProcedureDef] = Field(
         description=(
             "Named reusable procedures.  Keys are unique procedure names"
             " that may be referenced as a statement ``op``."

--- a/dwave/gate/qcdl/registers.py
+++ b/dwave/gate/qcdl/registers.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Type
 
 import numpy as np
 
-from .base import QcdlArgument, QcdlModuleContainerBase
+from .base import QCDLArgument, QCDLModuleContainerBase
 from .constants import (
     FLOAT_TO_INT,
     INT_TO_FLOAT,
@@ -43,7 +43,7 @@ from .exceptions import QCDLInternalError, QCDLUserError
 from .utils import is_qubit_or_coupler_name
 
 if TYPE_CHECKING:
-    from .components import Procedure, QcdlModule
+    from .components import Procedure, QCDLModule
 
 operators_to_math = {
     # special
@@ -224,7 +224,7 @@ class RegisterInitializerMixin:
 
     def _register_initialization(
         self,
-        modules: Sequence[QcdlModule],
+        modules: Sequence[QCDLModule],
         initial_value: Any,
         dtype: str | type,
         name: str | None = None,
@@ -294,13 +294,13 @@ class RegisterInitializerMixin:
         return self._value
 
     @property
-    def modules(self) -> Sequence[QcdlModule]:
+    def modules(self) -> Sequence[QCDLModule]:
         return self._modules
 
 
 def prepare_multiqubit_stmt(
-    modules: Sequence[QcdlModule],
-) -> tuple[QcdlModule, dict[str, Any]]:
+    modules: Sequence[QCDLModule],
+) -> tuple[QCDLModule, dict[str, Any]]:
     """Support for conversion of a set of identical statements on multiple
     qubits into one statement on a single qubit using the qubits kwarg"""
     other_qubits = [m for m in modules[1:]]
@@ -357,7 +357,7 @@ class OpsMixin:
 
     @staticmethod
     def _assert_compatible_modules(a: Any, b: Any) -> bool | None:
-        """We only allow objects with the same QcdlModules to interact with
+        """We only allow objects with the same QCDLModules to interact with
         each other"""
         mods: list[set[Any]] = [set(), set()]
         for i, obj in enumerate([a, b]):
@@ -557,7 +557,7 @@ class IntegerOpsMixin(NumberOpsMixin):
 
     # dev note: update the docstring when adding new methods
 
-class Target(OpsMixin, QcdlModuleContainerBase):
+class Target(OpsMixin, QCDLModuleContainerBase):
     """A Target represents a location on a qubit that may be written to. This
     object should not be directly instantiated by an end user."""
 
@@ -576,7 +576,7 @@ class Target(OpsMixin, QcdlModuleContainerBase):
 
     @property
     @abc.abstractmethod
-    def modules(self) -> Sequence[QcdlModule]:
+    def modules(self) -> Sequence[QCDLModule]:
         raise NotImplementedError
 
     @property
@@ -588,19 +588,19 @@ class Target(OpsMixin, QcdlModuleContainerBase):
         return False
 
     @property
-    def qcdl_modules(self) -> Sequence[QcdlModule]:
-        # this allows the procedure decorator to rewrap the QcdlModules for the
+    def qcdl_modules(self) -> Sequence[QCDLModule]:
+        # this allows the procedure decorator to rewrap the QCDLModules for the
         # invoked procedure
         return self.modules
 
 
-class RegisterExpression(IntegerOpsMixin, OpsMixin, QcdlArgument):
+class RegisterExpression(IntegerOpsMixin, OpsMixin, QCDLArgument):
     """An RegisterExpression is composed of operations on registers. It should not be
     instantiated by an end user"""
 
     def __init__(
         self,
-        modules: Sequence[QcdlModule],
+        modules: Sequence[QCDLModule],
         expr: str,
         scope_id: int | None = None,
         master_kwargs: dict[str, Any] | None = None,
@@ -612,7 +612,7 @@ class RegisterExpression(IntegerOpsMixin, OpsMixin, QcdlArgument):
         self.master_kwargs = master_kwargs
 
     def _emit_instructions(self) -> None:
-        """Generate the qcdl instruction and execute it on the QcdlModules"""
+        """Generate the qcdl instruction and execute it on the QCDLModules"""
         q, kwargs = prepare_multiqubit_stmt(self.modules)
         if self.master_kwargs:
             kwargs.update(self.master_kwargs)
@@ -667,7 +667,7 @@ class Register(IntegerOpsMixin, AssignmentOpsMixin, RegisterInitializerMixin, Ta
             already allocated (and does not raise an exception).
         scope_id: Identity of the :class:`~dwave.gate.qcdl.Scope` this register
             is derived from. The
-            :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Register` method sets
+            :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Register` method sets
             this value when you create a register from a
             :class:`~dwave.gate.qcdl.Scope` instance.
 
@@ -721,12 +721,12 @@ class Register(IntegerOpsMixin, AssignmentOpsMixin, RegisterInitializerMixin, Ta
 
     See Also:
         :class:`.FixedPointRegister`,
-        :meth:`~dwave.gate.qcdl.QcdlModuleContainer.Register`
+        :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Register`
     """
 
     def __init__(
         self,
-        modules: Sequence[QcdlModule],
+        modules: Sequence[QCDLModule],
         initial_value: int = 0,
         name: str | None = None,
         master_kwargs: dict[str, Any] | None = None,
@@ -784,7 +784,7 @@ class FixedPointRegister(
             already allocated (and does not raise an exception).
         scope_id: Identity of the :class:`~dwave.gate.qcdl.Scope` this register
             is derived from. The
-            :meth:`~dwave.gate.qcdl.QcdlModuleContainer.FixedPointRegister`
+            :meth:`~dwave.gate.qcdl.QCDLModuleContainer.FixedPointRegister`
             method sets this value when you create a register from a
             :class:`~dwave.gate.qcdl.Scope` instance.
 
@@ -819,12 +819,12 @@ class FixedPointRegister(
 
     See Also:
         :class:`.Register`,
-        :meth:`~dwave.gate.qcdl.QcdlModuleContainer.FixedPointRegister`
+        :meth:`~dwave.gate.qcdl.QCDLModuleContainer.FixedPointRegister`
     """
 
     def __init__(
         self,
-        modules: Sequence[QcdlModule],
+        modules: Sequence[QCDLModule],
         initial_value: float = 0.0,
         name: str | None = None,
         master_kwargs: dict[str, Any] | None = None,
@@ -850,7 +850,7 @@ class Output(Target):
     This class is intended for use by developers of QCDL and advanced users.
 
     You can write data to these outputs but not read from them. For usage, see
-    the :meth:`~dwave.gate.qcdl.QcdlModuleContainer.append_table_row` method.
+    the :meth:`~dwave.gate.qcdl.QCDLModuleContainer.append_table_row` method.
 
     Args:
         modules: Modules, typically qubits.
@@ -875,7 +875,7 @@ class Output(Target):
 
     def __init__(
         self,
-        modules: Sequence[QcdlModule],
+        modules: Sequence[QCDLModule],
         name: str | None = None,
         category: str | None = None,
         master_kwargs: dict[str, Any] | None = None,
@@ -928,7 +928,7 @@ class Output(Target):
         self._released = True
 
 
-class _SENS(IntegerOpsMixin, OpsMixin, QcdlArgument):
+class _SENS(IntegerOpsMixin, OpsMixin, QCDLArgument):
     """SENS is a read-only integer on the qubit that provides values read from
     the CPU sensors.
 
@@ -1018,7 +1018,7 @@ class Array(RegisterInitializerMixin):
 
     def __init__(
         self,
-        modules: Sequence[QcdlModule],
+        modules: Sequence[QCDLModule],
         initial_value: Any,
         name: str | None = None,
         dtype: str = "int",
@@ -1123,7 +1123,7 @@ class ExpressionAggregator:
 
     def __init__(
         self,
-        modules: Sequence[QcdlModule],
+        modules: Sequence[QCDLModule],
         master_kwargs: dict[str, Any] | None = None,
         scope_id: int | None = None,
     ) -> None:
@@ -1168,7 +1168,7 @@ class ExpressionAggregator:
 
 
 def arbitrary_function(
-    modules: Sequence[QcdlModule],
+    modules: Sequence[QCDLModule],
     in_dtype: Type[int] | Type[float],
     out_dtype: Type[int] | Type[float],
     name: str | None = None,

--- a/dwave/gate/qcdl/statement.py
+++ b/dwave/gate/qcdl/statement.py
@@ -20,7 +20,7 @@ from typing import Any, cast
 from addict import Addict
 
 from .exceptions import QCDLInternalError
-from .qcdl_models import QcdlStatement
+from .qcdl_models import QCDLStatement
 from .qcdl_objects import format_signature
 from .utils import is_qubit_name, is_qubit_or_coupler_name
 
@@ -28,10 +28,10 @@ logger = logging.getLogger(__name__)
 
 
 class Statement:
-    def __init__(self, statement: dict | QcdlStatement):
+    def __init__(self, statement: dict | QCDLStatement):
         stmt: dict = (
             statement.model_dump(exclude_unset=True)
-            if isinstance(statement, QcdlStatement)
+            if isinstance(statement, QCDLStatement)
             else statement
         )
         if not isinstance(stmt, dict):

--- a/dwave/gate/qcdl/transformer.py
+++ b/dwave/gate/qcdl/transformer.py
@@ -22,7 +22,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from .base import VariableExpression
-from .qcdl_models import Qcdl, QcdlProcedureDef, QcdlStatement
+from .qcdl_models import QCDLProgram, QCDLProcedureDef, QCDLStatement
 from .qcdl_objects import (
     AsmSync,
     ParserAsmInstruction,
@@ -48,15 +48,15 @@ except ImportError:
     HAVE_IPYTHON = False
 
 if TYPE_CHECKING:
-    from .qcdl_circuit import QcdlV2
+    from .qcdl_circuit import QCDLV2
 
 
 def transform_statement(
-    statement: QcdlStatement | dict,
+    statement: QCDLStatement | dict,
     label_suffix: str | None = None,
 ) -> ParserAsmInstruction | ProcedureCallStatement | AsmSync:
-    stmt: QcdlStatement = (
-        QcdlStatement.model_validate(statement)
+    stmt: QCDLStatement = (
+        QCDLStatement.model_validate(statement)
         if isinstance(statement, dict)
         else statement
     )
@@ -122,7 +122,7 @@ def transform_statement(
 
 
 def transform_statements(
-    statements: Sequence[QcdlStatement | dict],
+    statements: Sequence[QCDLStatement | dict],
     label_suffix: str | None = None,
 ) -> ParserAsmProgram:
     """Generally this is called for procedures or macros
@@ -137,12 +137,12 @@ def transform_statements(
 
 
 def transform_procedures(
-    procedures: Mapping[str, QcdlProcedureDef | dict],
+    procedures: Mapping[str, QCDLProcedureDef | dict],
 ) -> list[dict]:
     procs = []
     for proc_name, proc in procedures.items():
         if isinstance(proc, dict):
-            proc = QcdlProcedureDef.model_validate(proc)
+            proc = QCDLProcedureDef.model_validate(proc)
         prog = transform_statements(proc.statements)
         procs.append(
             dict(
@@ -164,13 +164,13 @@ def transform_procedures(
     return procs
 
 
-def transform_qcdl(qcdl: Qcdl | Mapping[str, Any]) -> dict:
+def transform_qcdl(qcdl: QCDLProgram | Mapping[str, Any]) -> dict:
     """This converts the output from QCDL into an object that
     mirrors what the lark parser produces from a .qcdl file.
     """
     if isinstance(qcdl, dict):
-        qcdl_model = Qcdl.model_validate(qcdl)
-    elif isinstance(qcdl, Qcdl):
+        qcdl_model = QCDLProgram.model_validate(qcdl)
+    elif isinstance(qcdl, QCDLProgram):
         qcdl_model = qcdl
     else:
         raise TypeError(f"QCDL must be a dictionary, not a {type(qcdl)}")
@@ -231,14 +231,14 @@ def transform_statements_to_qcdl_str(
     return txt
 
 
-def transform_program_to_qcdl_str(qcdl: dict) -> QcdlV2:
+def transform_program_to_qcdl_str(qcdl: dict) -> QCDLV2:
     txt = "begin quantum\n"
     txt += transform_statements_to_qcdl_str(qcdl["quantum_program"], initial_indent=3)
     txt += "end quantum\n"
     return txt
 
 
-def blacken_qcdl_str(qcdl_str: QcdlV2) -> QcdlV2:
+def blacken_qcdl_str(qcdl_str: QCDLV2) -> QCDLV2:
     """Treat the code like python and try to use black to reformat it"""
     blackened = []
     indent = 0
@@ -261,11 +261,11 @@ def blacken_qcdl_str(qcdl_str: QcdlV2) -> QcdlV2:
 
 
 def print_qcdl(
-    qcdl: Qcdl | Mapping[str, Any],
+    qcdl: QCDLProgram | Mapping[str, Any],
     to_Display: bool = True,
     blacken: bool = False,
     filename: str | None = None,
-) -> QcdlV2 | None:
+) -> QCDLV2 | None:
     """Print a QCDl program.
 
     Args:
@@ -308,7 +308,7 @@ def print_qcdl(
         return qcdl_str
 
 
-def display_qcdl(qcdl: Qcdl | Mapping[str, Any], **kwargs: Any) -> None:
+def display_qcdl(qcdl: QCDLProgram | Mapping[str, Any], **kwargs: Any) -> None:
     """Display formatted QCDL in a `Jupyter <https://jupyter.org/>`_ notebook or
     similar.
 

--- a/dwave/gate/results.py
+++ b/dwave/gate/results.py
@@ -32,7 +32,7 @@ import polars as pl
 
 from dwave.gate.qcdl import LogicalOutcomeToInteger
 from dwave.gate.qcdl.records import RecordFormat
-from dwave.gate.qcdl.qcdl_models import Qcdl
+from dwave.gate.qcdl.qcdl_models import QCDLProgram
 
 logger = logging.getLogger(__name__)
 
@@ -379,10 +379,10 @@ class Result(BaseModel):
         ),
     )
 
-    executed_qcdl: Qcdl | None = Field(
+    executed_qcdl: QCDLProgram | None = Field(
         default=None,
         description=(
-            "The :class:`~dwave.gate.qcdl.qcdl_models.Qcdl` payload"
+            "The :class:`~dwave.gate.qcdl.qcdl_models.QCDLProgram` payload"
             " representing the program that was executed."
         ),
     )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -22,7 +22,7 @@ from dwave.gate.qcdl import print_qcdl, procedure, qcdl
 from dwave.gate.qcdl.base import Variable, VariableExpression
 
 
-def test_QcdlArguments():
+def test_QCDLArguments():
     @qcdl(2)
     def main(q0, q1, **kwargs):
         @procedure

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -29,12 +29,12 @@ from dwave.gate.qcdl import (
 from dwave.gate.qcdl.components import (
     IndexerMixin,
     Procedure,
-    QcdlModule,
-    QcdlStatementBridge,
+    QCDLModule,
+    QCDLStatementBridge,
     objwalk,
 )
-from dwave.gate.qcdl.qcdl_circuit import QcdlCircuit
-from dwave.gate.qcdl.qcdl_models import QcdlStatement
+from dwave.gate.qcdl.qcdl_circuit import QCDLCircuit
+from dwave.gate.qcdl.qcdl_models import QCDLStatement
 
 
 def _check_serializable(data):
@@ -55,7 +55,7 @@ def test_unwrap():
         [1, dict(a=1, b=2), 2],
         np.arange(10),
     ]:
-        new_cont = QcdlModule.unwrap(cont)
+        new_cont = QCDLModule.unwrap(cont)
 
         if not isinstance(cont, int):
             assert cont is not new_cont
@@ -169,7 +169,7 @@ def test_scope_id():
     assert isinstance(scope_id, int)
 
     for stmt in qcdl_input["program"]["statements"]:
-        s = QcdlStatement.model_validate(stmt)
+        s = QCDLStatement.model_validate(stmt)
         assert s.kwargs["scope_id"] == scope_id
 
 
@@ -177,7 +177,7 @@ def test_procedure_op_key():
     num_qubits = 4
 
     @procedure
-    def my_proc(sender: QcdlModule, register: Register):
+    def my_proc(sender: QCDLModule, register: Register):
         sender.x()
         register += 1
 
@@ -204,7 +204,7 @@ def test_serialization_error():
         def default(self, obj):
             if isinstance(obj, np.ndarray):
                 return obj.tolist()
-            if isinstance(obj, QcdlStatementBridge):
+            if isinstance(obj, QCDLStatementBridge):
                 raise QCDLUserError(f"Unresolved statement {obj}")
 
             try:
@@ -216,7 +216,7 @@ def test_serialization_error():
 
     with pytest.raises(QCDLUserError, match="not_an_element"):
         for path, a in objwalk(val):
-            if isinstance(a, QcdlStatementBridge):
+            if isinstance(a, QCDLStatementBridge):
                 dotted_path = ".".join([str(p) for p in path])
                 raise QCDLUserError(f"Unresolved statement {a} at {dotted_path}")
 
@@ -247,7 +247,7 @@ def test_unique_statements_to_procs():
 
 
 def test_get_next_index():
-    circuit = QcdlCircuit()
+    circuit = QCDLCircuit()
     objs = [circuit, IndexerMixin(), Procedure("myproc", circuit)]
 
     for obj in objs:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -19,7 +19,7 @@ from pytest_mock import MockerFixture
 
 import dwave.gate.qcdl.implementations
 from dwave.gate.qcdl import (
-    QcdlModule,
+    QCDLModule,
     QCDLUserError,
     Register,
     Scope,
@@ -28,7 +28,7 @@ from dwave.gate.qcdl import (
     qcdl,
 )
 from dwave.gate.qcdl.operations import AngleType
-from dwave.gate.qcdl.qcdl_models import QcdlStatement
+from dwave.gate.qcdl.qcdl_models import QCDLStatement
 
 available_operations = [
     name
@@ -50,7 +50,7 @@ def test_operations(op_name):
         [
             1
             for parameter in sig.parameters.values()
-            if parameter.annotation == QcdlModule
+            if parameter.annotation == QCDLModule
         ]
     )
 
@@ -95,7 +95,7 @@ def test_operations(op_name):
     qcdl_dict = main().model_dump(exclude_unset=True)
 
     for stmt in qcdl_dict["program"]["statements"]:
-        statement = QcdlStatement.model_validate(stmt)
+        statement = QCDLStatement.model_validate(stmt)
         if statement.op == op_name:
             break
         if op_name in ["sy", "sydg"]:

--- a/tests/test_qcdl_circuit.py
+++ b/tests/test_qcdl_circuit.py
@@ -26,8 +26,8 @@ import pickle
 import pytest
 
 from dwave.gate.qcdl import QCDLUserError, qcdl
-from dwave.gate.qcdl.qcdl_circuit import QcdlCircuit, _get_fspec
-from dwave.gate.qcdl.qcdl_models import Qcdl
+from dwave.gate.qcdl.qcdl_circuit import QCDLCircuit, _get_fspec
+from dwave.gate.qcdl.qcdl_models import QCDLProgram
 
 # ---------------------------------------------------------------------------
 # Shared test doubles
@@ -83,7 +83,7 @@ class CallTracker:
 def make_fake_machine(env, tracker: CallTracker | None = None):
     """Return a FakeMachine class and its associated CallTracker.
 
-    The machine promotes qubit/coupler names to QcdlModule objects via
+    The machine promotes qubit/coupler names to QCDLModule objects via
     proc.q(name) inside set_up_systems, matching real machine behaviour.
     Non-qubit kwargs (e.g. user-supplied floats) are left untouched.
     """
@@ -118,7 +118,7 @@ def make_fake_machine(env, tracker: CallTracker | None = None):
 # ---------------------------------------------------------------------------
 
 
-class TestQcdlQubitSourceModes:
+class TestQCDLQubitSourceModes:
     """@qcdl infers/creates qubits differently depending on its arguments."""
 
     def test_infer_qubit_names_from_signature(self):
@@ -134,7 +134,7 @@ class TestQcdlQubitSourceModes:
             q1.measure()
 
         result = main()
-        assert isinstance(result, Qcdl)
+        assert isinstance(result, QCDLProgram)
         assert set(received) == {"q0", "q1"}
 
     def test_non_qubit_args_not_auto_injected(self):
@@ -148,7 +148,7 @@ class TestQcdlQubitSourceModes:
             q0.measure()
 
         result = main(angle=1.5)
-        assert isinstance(result, Qcdl)
+        assert isinstance(result, QCDLProgram)
         assert received["angle"] == 1.5
 
     def test_coupler_name_inferred_from_signature(self):
@@ -161,7 +161,7 @@ class TestQcdlQubitSourceModes:
             q0.measure()
 
         result = main()
-        assert isinstance(result, Qcdl)
+        assert isinstance(result, QCDLProgram)
         assert "c0" in received
 
     def test_num_qubits_creates_exact_count(self):
@@ -175,7 +175,7 @@ class TestQcdlQubitSourceModes:
             q0.measure()
 
         result = main()
-        assert isinstance(result, Qcdl)
+        assert isinstance(result, QCDLProgram)
         assert set(received) == {"q0", "q1", "q2"}
 
     def test_environment_mode_uses_initialize_modules(self):
@@ -190,7 +190,7 @@ class TestQcdlQubitSourceModes:
             q0.measure()
 
         result = main()
-        assert isinstance(result, Qcdl)
+        assert isinstance(result, QCDLProgram)
         assert set(received) == {"q0", "q1"}
 
     def test_environment_exposes_all_modules_to_varkw_function(self):
@@ -205,7 +205,7 @@ class TestQcdlQubitSourceModes:
             kwargs["q0"].measure()
 
         result = main()
-        assert isinstance(result, Qcdl)
+        assert isinstance(result, QCDLProgram)
         assert set(received) == {"q0", "q1", "q2"}
 
     def test_to_qcdlv2_returns_string(self):
@@ -225,7 +225,7 @@ class TestQcdlQubitSourceModes:
 # ---------------------------------------------------------------------------
 
 
-class TestQcdlMachine:
+class TestQCDLMachine:
     """Tests for the machine= path through @qcdl."""
 
     def setup_method(self):
@@ -378,7 +378,7 @@ class TestQcdlMachine:
 # ---------------------------------------------------------------------------
 
 
-class TestQcdlKwargsFiltering:
+class TestQCDLKwargsFiltering:
     """Tests for how @qcdl decides which kwargs to pass to the circuit function.
 
     If f has no **kwargs, only keys matching f's explicit argument names are
@@ -437,7 +437,7 @@ class TestQcdlKwargsFiltering:
 
         # Passing an unexpected kwarg should not raise; it is simply dropped.
         result = main(unknown_param=99)
-        assert isinstance(result, Qcdl)
+        assert isinstance(result, QCDLProgram)
 
     def test_varkw_receives_user_kwargs_alongside_qubits(self):
         """With **kwargs, caller kwargs are forwarded alongside qubits."""
@@ -490,7 +490,7 @@ class TestQcdlKwargsFiltering:
 # ---------------------------------------------------------------------------
 
 
-class TestQcdlUserKwargsMerging:
+class TestQCDLUserKwargsMerging:
     """User-supplied kwargs are merged into module_kwargs before being passed."""
 
     def test_user_kwargs_reach_circuit_body(self):
@@ -543,15 +543,15 @@ class TestQcdlUserKwargsMerging:
 
         decorated = qcdl()(MyCircuit())
         result = decorated(my_kwarg="hello")
-        assert isinstance(result, Qcdl)
+        assert isinstance(result, QCDLProgram)
         assert received["my_kwarg"] == "hello"
 
 
-class TestQcdlCircuitStateAndOutputs:
-    """Tests for QcdlCircuit stateful internals and output resource handling."""
+class TestQCDLCircuitStateAndOutputs:
+    """Tests for QCDLCircuit stateful internals and output resource handling."""
 
     def test_output_resources(self):
-        qcdl_obj = QcdlCircuit()
+        qcdl_obj = QCDLCircuit()
 
         class Mock:
             pass
@@ -616,7 +616,7 @@ class TestQcdlCircuitStateAndOutputs:
         assert qcdl_json2.next_indices[idx_name] == num_first + num_second
 
 
-class TestQcdlDecoratorModes:
+class TestQCDLDecoratorModes:
     """Tests decorator mode equivalence across function and method callables."""
 
     def test_qcdl_decorator_equivalent_function_modes(self):
@@ -650,10 +650,10 @@ class TestQcdlDecoratorModes:
     def test_qcdl_decorator_class_method_mode(self):
         rand_num = 1234
 
-        class QcdlDec(object):
+        class QCDLDec(object):
             @qcdl()
             def sequence(self, q0, q1, q2, my_kwarg=None, **kwargs):
-                assert isinstance(self, QcdlDec)
+                assert isinstance(self, QCDLDec)
                 assert my_kwarg in [4, rand_num]
                 _qcdl_decorator_reference(q0, q1, q2, my_kwarg)
 
@@ -661,7 +661,7 @@ class TestQcdlDecoratorModes:
         def main_env(q0, q1, q2, my_kwarg=None, **kwargs):
             _qcdl_decorator_reference(q0, q1, q2, my_kwarg)
 
-        obj = QcdlDec()
+        obj = QCDLDec()
         qcdl_json = obj.sequence(my_kwarg=4)
         _check_serializable(qcdl_json)
         _assert_statement_count(qcdl_json)

--- a/tests/test_qcdl_models.py
+++ b/tests/test_qcdl_models.py
@@ -17,7 +17,7 @@
 
 The fixtures mirror the sparse dict format that
 :meth:`~dwave.gate.qcdl.components.Procedure.add_statement` and
-:meth:`~dwave.gate.qcdl.qcdl_circuit.QcdlCircuit.to_model` actually produce, so
+:meth:`~dwave.gate.qcdl.qcdl_circuit.QCDLCircuit.to_model` actually produce, so
 that tests remain grounded in the real serialisation behaviour.
 """
 
@@ -32,15 +32,15 @@ from pydantic import BaseModel, ValidationError
 from dwave.gate.qcdl import procedure, qcdl
 from dwave.gate.qcdl.exceptions import QCDLInternalError
 from dwave.gate.qcdl.qcdl_models import (
-    Qcdl,
-    QcdlModuleName,
-    QcdlProcedureDef,
-    QcdlSignature,
-    QcdlStatement,
+    QCDLProgram,
+    QCDLModuleName,
+    QCDLProcedureDef,
+    QCDLSignature,
+    QCDLStatement,
 )
 
 # ---------------------------------------------------------------------------
-# Fixtures: minimal valid raw dicts mirroring QcdlCircuit.to_model() output
+# Fixtures: minimal valid raw dicts mirroring QCDLCircuit.to_model() output
 # ---------------------------------------------------------------------------
 
 
@@ -104,7 +104,7 @@ def minimal_qcdl(minimal_procedure_def) -> dict:
 
 def _strip_compat_name(obj: Any) -> Any:
     """Recursively remove the backward-compat ``"name"`` key that
-    ``QcdlStatement`` emits alongside ``"qubit"`` for server
+    ``QCDLStatement`` emits alongside ``"qubit"`` for server
     compatibility.  Used in round-trip tests so that source fixtures
     (which only contain ``"qubit"``) compare equal to dumped output."""
     if isinstance(obj, list):
@@ -119,86 +119,86 @@ def _strip_compat_name(obj: Any) -> Any:
 
 
 # ---------------------------------------------------------------------------
-# QcdlModuleName
+# QCDLModuleName
 # ---------------------------------------------------------------------------
 
 
-class TestQcdlModuleName:
+class TestQCDLModuleName:
     def test_validate_qubit_from_string(self):
-        m = QcdlModuleName.model_validate("q0")
+        m = QCDLModuleName.model_validate("q0")
         assert m.kind == "qubit"
         assert m.index == 0
         assert m.name == "q0"
 
     def test_validate_coupler_from_string(self):
-        m = QcdlModuleName.model_validate("c3")
+        m = QCDLModuleName.model_validate("c3")
         assert m.kind == "coupler"
         assert m.index == 3
         assert m.name == "c3"
 
     def test_validate_from_dict(self):
-        m = QcdlModuleName.model_validate({"kind": "qubit", "index": 7})
+        m = QCDLModuleName.model_validate({"kind": "qubit", "index": 7})
         assert m.name == "q7"
 
     def test_invalid_name_raises(self):
         with pytest.raises(Exception):
-            QcdlModuleName.model_validate("0q")  # digit-leading not allowed
+            QCDLModuleName.model_validate("0q")  # digit-leading not allowed
         with pytest.raises(Exception):
-            QcdlModuleName.model_validate("q-1")  # non-alphanumeric not allowed
+            QCDLModuleName.model_validate("q-1")  # non-alphanumeric not allowed
 
     def test_mixed_case_prefix_no_index(self):
-        m = QcdlModuleName.model_validate("qubitA")
+        m = QCDLModuleName.model_validate("qubitA")
         assert m.kind == "qubitA"
         assert m.index is None
         assert m.name == "qubitA"
 
     def test_mixed_case_prefix_with_index(self):
-        m = QcdlModuleName.model_validate("qubitA0")
+        m = QCDLModuleName.model_validate("qubitA0")
         assert m.kind == "qubitA"
         assert m.index == 0
         assert m.name == "qubitA0"
 
     def test_case_insensitive_kind_dict(self):
-        m = QcdlModuleName.model_validate({"kind": "QubitA", "index": None})
+        m = QCDLModuleName.model_validate({"kind": "QubitA", "index": None})
         assert m.kind == "QubitA"
         assert m.name == "QubitA"
 
     def test_is_qubit_true(self):
-        assert QcdlModuleName.model_validate("q1").is_qubit
+        assert QCDLModuleName.model_validate("q1").is_qubit
 
     def test_is_coupler_true(self):
-        assert QcdlModuleName.model_validate("c0").is_coupler
+        assert QCDLModuleName.model_validate("c0").is_coupler
 
     def test_str_returns_name(self):
-        assert str(QcdlModuleName.model_validate("q5")) == "q5"
+        assert str(QCDLModuleName.model_validate("q5")) == "q5"
 
     def test_eq_with_model(self):
-        a = QcdlModuleName.model_validate("q2")
-        b = QcdlModuleName.model_validate("q2")
+        a = QCDLModuleName.model_validate("q2")
+        b = QCDLModuleName.model_validate("q2")
         assert a == b
 
     def test_eq_with_string(self):
-        m = QcdlModuleName.model_validate("q2")
+        m = QCDLModuleName.model_validate("q2")
         assert m == "q2"
         assert m != "q3"
 
     def test_hash_matches_string_hash(self):
-        m = QcdlModuleName.model_validate("q0")
+        m = QCDLModuleName.model_validate("q0")
         assert hash(m) == hash("q0")
 
     def test_serialises_to_string_via_model_dump(self):
         """model_dump() on a parent must still produce plain strings."""
-        stmt = QcdlStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
+        stmt = QCDLStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
         dumped = stmt.model_dump()
         assert dumped["qubits"] == ["q0", "q1"]
 
     def test_frozen(self):
-        m = QcdlModuleName.model_validate("q0")
+        m = QCDLModuleName.model_validate("q0")
         with pytest.raises(Exception):
             m.index = 99  # type: ignore[misc]
 
     def test_arbitrary_prefix_from_string(self):
-        m = QcdlModuleName.model_validate("m0")
+        m = QCDLModuleName.model_validate("m0")
         assert m.kind == "m"
         assert m.prefix == "m"
         assert m.index == 0
@@ -207,19 +207,19 @@ class TestQcdlModuleName:
         assert not m.is_coupler
 
     def test_arbitrary_prefix_multi_char(self):
-        m = QcdlModuleName.model_validate("dr3")
+        m = QCDLModuleName.model_validate("dr3")
         assert m.kind == "dr"
         assert m.prefix == "dr"
         assert m.index == 3
         assert m.name == "dr3"
 
     def test_arbitrary_prefix_from_dict(self):
-        m = QcdlModuleName.model_validate({"kind": "m", "index": 1})
+        m = QCDLModuleName.model_validate({"kind": "m", "index": 1})
         assert m.name == "m1"
 
     def test_arbitrary_prefix_round_trips_via_serializer(self):
         """model_dump() must serialize arbitrary-prefix modules to plain strings."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "sync", "qubit": "m0", "kwargs": {"qubits": ["m0", "m1"]}}
         )
         dumped = stmt.model_dump()
@@ -227,35 +227,35 @@ class TestQcdlModuleName:
         assert dumped["qubits"] == ["m0", "m1"]
 
     def test_prefix_property_for_qubit_and_coupler(self):
-        assert QcdlModuleName.model_validate("q4").prefix == "q"
-        assert QcdlModuleName.model_validate("c2").prefix == "c"
+        assert QCDLModuleName.model_validate("q4").prefix == "q"
+        assert QCDLModuleName.model_validate("c2").prefix == "c"
 
     def test_no_index_qubit(self):
-        m = QcdlModuleName.model_validate("q")
+        m = QCDLModuleName.model_validate("q")
         assert m.kind == "qubit"
         assert m.index is None
         assert m.name == "q"
         assert m.is_qubit
 
     def test_no_index_coupler(self):
-        m = QcdlModuleName.model_validate("c")
+        m = QCDLModuleName.model_validate("c")
         assert m.kind == "coupler"
         assert m.index is None
         assert m.name == "c"
         assert m.is_coupler
 
     def test_no_index_arbitrary_prefix(self):
-        m = QcdlModuleName.model_validate("m")
+        m = QCDLModuleName.model_validate("m")
         assert m.kind == "m"
         assert m.index is None
         assert m.name == "m"
 
     def test_no_index_from_dict(self):
-        m = QcdlModuleName.model_validate({"kind": "m", "index": None})
+        m = QCDLModuleName.model_validate({"kind": "m", "index": None})
         assert m.name == "m"
 
     def test_no_index_serialises_to_string(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "h", "qubit": "q", "kwargs": {"qubits": ["q", "m"]}}
         )
         dumped = stmt.model_dump()
@@ -264,13 +264,13 @@ class TestQcdlModuleName:
 
 
 # ---------------------------------------------------------------------------
-# QcdlStatement
+# QCDLStatement
 # ---------------------------------------------------------------------------
 
 
-class TestQcdlStatement:
+class TestQCDLStatement:
     def test_all_fields_present(self, minimal_statement):
-        stmt = QcdlStatement.model_validate(minimal_statement)
+        stmt = QCDLStatement.model_validate(minimal_statement)
         assert stmt.op == "h"
         assert stmt.qubit == "q0"
         assert stmt.args == []
@@ -281,23 +281,23 @@ class TestQcdlStatement:
         assert stmt.qubits == ["q0"]
 
     def test_op_none_is_valid(self):
-        stmt = QcdlStatement.model_validate({})
+        stmt = QCDLStatement.model_validate({})
         assert stmt.op is None
 
     def test_op_valid_identifiers(self):
         for op in ["h", "cx", "_if", "c_if_else", "my_gate2", "_", "__init__"]:
-            stmt = QcdlStatement.model_validate({"op": op})
+            stmt = QCDLStatement.model_validate({"op": op})
             assert stmt.op == op
 
     def test_op_invalid_raises(self):
         for bad in ["1h", "h-gate", "cx!", "my gate", "op.name"]:
             with pytest.raises(ValidationError):
-                QcdlStatement.model_validate({"op": bad})
+                QCDLStatement.model_validate({"op": bad})
 
     def test_extra_fields_preserved(self):
         """Extra keys (e.g. card_name) round-trip via model_dump()."""
         raw = {"op": "rx", "qubit": "q0", "kwargs": {"theta": 1.5, "card_name": "c0"}}
-        stmt = QcdlStatement.model_validate(raw)
+        stmt = QCDLStatement.model_validate(raw)
         dumped = stmt.model_dump()
         assert dumped["op"] == "rx"
         assert dumped["kwargs"]["card_name"] == "c0"
@@ -305,21 +305,21 @@ class TestQcdlStatement:
     def test_sparse_round_trip(self, sparse_statement):
         """exclude_unset=True with exclude_computed_fields=True reproduces the
         sparse add_statement output."""
-        model = QcdlStatement.model_validate(sparse_statement)
+        model = QCDLStatement.model_validate(sparse_statement)
         dumped = model.model_dump(exclude_unset=True, exclude_computed_fields=True)
         dumped.pop("name", None)  # backward-compat alias — not in source fixture
         assert dumped == sparse_statement
 
     def test_dense_round_trip(self, minimal_statement):
         """All fields present round-trip without loss."""
-        model = QcdlStatement.model_validate(minimal_statement)
+        model = QCDLStatement.model_validate(minimal_statement)
         dumped = model.model_dump()
         dumped.pop("name", None)  # backward-compat alias — not in source fixture
         assert dumped == minimal_statement
 
     def test_call_qubits_populated_from_call_qubits_key(self):
         """caller_qubits is populated from the explicit 'caller_qubits' key."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "my_proc", "qubit": None, "caller_qubits": ["q0", "q1"]}
         )
         assert stmt.caller_qubits == ["q0", "q1"]
@@ -327,7 +327,7 @@ class TestQcdlStatement:
     def test_call_qubits_serializes_as_call_qubits_key(self):
         """caller_qubits appears as 'caller_qubits' in model_dump(); qubits holds
         the computed list."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "my_proc", "qubit": None, "caller_qubits": ["q0", "q1"]}
         )
         dumped = stmt.model_dump()
@@ -337,7 +337,7 @@ class TestQcdlStatement:
 
     def test_qubits_in_serialized_output(self):
         """The computed qubits field is included in model_dump()."""
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         dumped = stmt.model_dump()
         assert "qubits" in dumped
         assert dumped["qubits"] == ["q0"]
@@ -345,7 +345,7 @@ class TestQcdlStatement:
 
     def test_args_and_qubits_list(self):
         """qubits (computed) aggregates from all sources, deduped."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "cx", "qubit": "q0", "args": ["q0", "q1"], "qubits": ["q0", "q1"]}
         )
         assert stmt.args == ["q0", "q1"]
@@ -355,18 +355,18 @@ class TestQcdlStatement:
 
     def test_qubits_gate_includes_qubit_field(self):
         """qubits includes the qubit field for a simple gate."""
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         assert stmt.qubits == ["q0"]
 
     def test_qubits_from_arg(self):
         """qubits includes qubit-like strings in args for non-opaque ops."""
-        stmt = QcdlStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
+        stmt = QCDLStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
         assert "q0" in stmt.qubits
         assert "q1" in stmt.qubits
 
     def test_qubits_from_call_qubits_field(self):
         """qubits includes entries from the explicit caller_qubits field."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "my_proc", "qubit": None, "caller_qubits": ["q0", "q1"]}
         )
         assert "q0" in stmt.qubits
@@ -374,7 +374,7 @@ class TestQcdlStatement:
 
     def test_qubits_from_kwargs_qubits_key(self):
         """qubits includes names from kwargs['qubits']."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "sync", "qubit": "q0", "kwargs": {"qubits": ["q1", "q2"]}}
         )
         assert "q0" in stmt.qubits
@@ -384,20 +384,20 @@ class TestQcdlStatement:
     def test_qubits_deduped(self):
         """qubits never contains duplicates even if the same name appears
         in multiple sources."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "h", "qubit": "q0", "qubits": ["q0"]}
         )
         assert stmt.qubits.count("q0") == 1
 
     def test_qubits_includes_couplers(self):
         """qubits includes coupler modules (not just qubits)."""
-        stmt = QcdlStatement.model_validate({"op": "cz", "qubit": "q0", "args": ["c0"]})
+        stmt = QCDLStatement.model_validate({"op": "cz", "qubit": "q0", "args": ["c0"]})
         assert "q0" in stmt.qubits
         assert "c0" in stmt.qubits
 
     def test_qubits_opaque_for_comment(self):
         """For comment, args are opaque and must not be extracted."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "comment", "qubit": "q0", "args": ["q1"]}
         )
         assert stmt.qubits == ["q0"]
@@ -405,12 +405,12 @@ class TestQcdlStatement:
 
     def test_qubits_opaque_for_if(self):
         """For If, args are opaque."""
-        stmt = QcdlStatement.model_validate({"op": "If", "qubit": "q0", "args": ["q1"]})
+        stmt = QCDLStatement.model_validate({"op": "If", "qubit": "q0", "args": ["q1"]})
         assert stmt.qubits == ["q0"]
 
     def test_qubits_opaque_for_c_if(self):
         """For c_if, args are opaque."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "c_if", "qubit": "q0", "args": ["q1"]}
         )
         assert stmt.qubits == ["q0"]
@@ -418,7 +418,7 @@ class TestQcdlStatement:
     def test_qubits_if_else_kwargs(self):
         """For If/Else/Endif, qubit-valued kwargs (except condition/source_qubit)
         are added to qubits."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {
                 "op": "If",
                 "qubit": "q0",
@@ -432,7 +432,7 @@ class TestQcdlStatement:
 
     def test_qubits_procedure_call_no_qubit_field(self):
         """Procedure calls (qubit=None) still populate qubits from caller_qubits."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "my_proc", "qubit": None, "caller_qubits": ["q0", "q1", "q2"]}
         )
         assert stmt.is_procedure_call
@@ -440,13 +440,13 @@ class TestQcdlStatement:
 
 
 # ---------------------------------------------------------------------------
-# QcdlSignature
+# QCDLSignature
 # ---------------------------------------------------------------------------
 
 
-class TestQcdlSignature:
+class TestQCDLSignature:
     def test_valid_construction(self, minimal_signature):
-        sig = QcdlSignature.model_validate(minimal_signature)
+        sig = QCDLSignature.model_validate(minimal_signature)
         assert sig.qcdl_operator is None
         assert sig.qubits == ["q0"]
         assert sig.qubits_used == ["q0"]
@@ -456,124 +456,124 @@ class TestQcdlSignature:
     def test_null_qcdl_operator_allowed(self, minimal_signature):
         """qcdl_operator may legitimately be None."""
         minimal_signature["qcdl_operator"] = None
-        sig = QcdlSignature.model_validate(minimal_signature)
+        sig = QCDLSignature.model_validate(minimal_signature)
         assert sig.qcdl_operator is None
 
     def test_named_qcdl_operator(self, minimal_signature):
         minimal_signature["qcdl_operator"] = "h"
-        sig = QcdlSignature.model_validate(minimal_signature)
+        sig = QCDLSignature.model_validate(minimal_signature)
         assert sig.qcdl_operator == "h"
 
     def test_missing_required_field_raises(self, minimal_signature):
         del minimal_signature["qubits"]
         with pytest.raises(ValidationError):
-            QcdlSignature.model_validate(minimal_signature)
+            QCDLSignature.model_validate(minimal_signature)
 
     def test_extra_keys_rejected(self, minimal_signature):
         """extra='forbid' mirrors the strict TypedDict (no extra_items)."""
         minimal_signature["unknown_key"] = "bad"
         with pytest.raises(ValidationError):
-            QcdlSignature.model_validate(minimal_signature)
+            QCDLSignature.model_validate(minimal_signature)
 
     def test_round_trip(self, minimal_signature):
-        model = QcdlSignature.model_validate(minimal_signature)
+        model = QCDLSignature.model_validate(minimal_signature)
         assert model.model_dump() == minimal_signature
 
 
 # ---------------------------------------------------------------------------
-# QcdlProcedureDef
+# QCDLProcedureDef
 # ---------------------------------------------------------------------------
 
 
-class TestQcdlProcedureDef:
+class TestQCDLProcedureDef:
     def test_valid_construction(self, minimal_procedure_def):
-        proc = QcdlProcedureDef.model_validate(minimal_procedure_def)
+        proc = QCDLProcedureDef.model_validate(minimal_procedure_def)
         assert proc.statement_hash == "abc123"
         assert len(proc.statements) == 1
-        assert isinstance(proc.statements[0], QcdlStatement)
-        assert isinstance(proc.signature, QcdlSignature)
+        assert isinstance(proc.statements[0], QCDLStatement)
+        assert isinstance(proc.signature, QCDLSignature)
 
     def test_empty_statements_allowed(self, minimal_procedure_def):
         minimal_procedure_def["statements"] = []
-        proc = QcdlProcedureDef.model_validate(minimal_procedure_def)
+        proc = QCDLProcedureDef.model_validate(minimal_procedure_def)
         assert proc.statements == []
 
     def test_nested_statement_validation(self, minimal_procedure_def):
-        """Nested dicts are coerced to QcdlStatement instances."""
+        """Nested dicts are coerced to QCDLStatement instances."""
         minimal_procedure_def["statements"] = [
             {"op": "h", "qubit": "q0"},
             {"op": "measure", "qubit": "q0"},
         ]
-        proc = QcdlProcedureDef.model_validate(minimal_procedure_def)
-        assert all(isinstance(s, QcdlStatement) for s in proc.statements)
+        proc = QCDLProcedureDef.model_validate(minimal_procedure_def)
+        assert all(isinstance(s, QCDLStatement) for s in proc.statements)
 
     def test_bad_nested_signature_propagates_error(self, minimal_procedure_def):
         """ValidationError from a nested model bubbles up."""
         minimal_procedure_def["signature"]["qubits"] = "not-a-list"
         with pytest.raises(ValidationError):
-            QcdlProcedureDef.model_validate(minimal_procedure_def)
+            QCDLProcedureDef.model_validate(minimal_procedure_def)
 
     def test_missing_statement_hash_is_none(self, minimal_procedure_def):
         del minimal_procedure_def["statement_hash"]
-        model = QcdlProcedureDef.model_validate(minimal_procedure_def)
+        model = QCDLProcedureDef.model_validate(minimal_procedure_def)
         assert model.statement_hash is None
 
     def test_extra_keys_rejected(self, minimal_procedure_def):
         minimal_procedure_def["extra_field"] = "nope"
         with pytest.raises(ValidationError):
-            QcdlProcedureDef.model_validate(minimal_procedure_def)
+            QCDLProcedureDef.model_validate(minimal_procedure_def)
 
     def test_round_trip(self, minimal_procedure_def):
         expected = {
             k: v for k, v in minimal_procedure_def.items() if k != "statement_hash"
         }
-        model = QcdlProcedureDef.model_validate(minimal_procedure_def)
+        model = QCDLProcedureDef.model_validate(minimal_procedure_def)
         assert _strip_compat_name(model.model_dump()) == expected
 
 
 # ---------------------------------------------------------------------------
-# Qcdl
+# QCDL
 # ---------------------------------------------------------------------------
 
 
-class TestQcdl:
+class TestQCDL:
     def test_valid_construction(self, minimal_qcdl):
-        model = Qcdl.model_validate(minimal_qcdl)
-        assert isinstance(model.program, QcdlProcedureDef)
+        model = QCDLProgram.model_validate(minimal_qcdl)
+        assert isinstance(model.program, QCDLProcedureDef)
         assert model.procedures == {}
         assert model.next_indices == {}
 
     def test_named_procedure_accepted(self, minimal_qcdl, minimal_procedure_def):
         minimal_qcdl["procedures"]["my_proc"] = minimal_procedure_def
-        model = Qcdl.model_validate(minimal_qcdl)
+        model = QCDLProgram.model_validate(minimal_qcdl)
         assert "my_proc" in model.procedures
-        assert isinstance(model.procedures["my_proc"], QcdlProcedureDef)
+        assert isinstance(model.procedures["my_proc"], QCDLProcedureDef)
         assert model.procedures["my_proc"].statement_hash == "abc123"
 
     def test_extra_fields_preserved(self, minimal_qcdl):
         """Extra top-level keys are preserved via extra="allow"."""
         minimal_qcdl["compiler_hint"] = "fast_path"
-        model = Qcdl.model_validate(minimal_qcdl)
+        model = QCDLProgram.model_validate(minimal_qcdl)
         assert model.model_dump()["compiler_hint"] == "fast_path"
 
     def test_missing_required_field_raises(self, minimal_qcdl):
         del minimal_qcdl["procedures"]
         with pytest.raises(ValidationError):
-            Qcdl.model_validate(minimal_qcdl)
+            QCDLProgram.model_validate(minimal_qcdl)
 
     def test_next_indices_round_trip(self, minimal_qcdl):
         minimal_qcdl["next_indices"] = {"label": 3, "axis": 7}
-        model = Qcdl.model_validate(minimal_qcdl)
+        model = QCDLProgram.model_validate(minimal_qcdl)
         assert model.next_indices == {"label": 3, "axis": 7}
 
     def test_round_trip(self, minimal_qcdl):
         expected = copy.deepcopy(minimal_qcdl)
         expected["program"].pop("statement_hash", None)
-        model = Qcdl.model_validate(minimal_qcdl)
+        model = QCDLProgram.model_validate(minimal_qcdl)
         assert _strip_compat_name(model.model_dump()) == expected
 
     def test_validate_from_qcdl_circuit(self):
-        """Integration: @qcdl returns a Qcdl directly."""
+        """Integration: @qcdl returns a QCDL directly."""
 
         @qcdl()
         def my_circuit(q0):
@@ -582,9 +582,9 @@ class TestQcdl:
 
         model = my_circuit()
 
-        assert isinstance(model, Qcdl)
-        assert isinstance(model.program, QcdlProcedureDef)
-        assert all(isinstance(s, QcdlStatement) for s in model.program.statements)
+        assert isinstance(model, QCDLProgram)
+        assert isinstance(model.program, QCDLProcedureDef)
+        assert all(isinstance(s, QCDLStatement) for s in model.program.statements)
         ops = [s.op for s in model.program.statements]
         assert "h" in ops
         assert "measure" in ops
@@ -606,7 +606,7 @@ class TestQcdl:
         assert "signature" in dumped["program"]
 
     def test_to_model_dump_contains_no_pydantic_models(self):
-        """model_dump() on the Qcdl returned by @qcdl must produce pure
+        """model_dump() on the QCDL returned by @qcdl must produce pure
         Python — no BaseModel instances anywhere.
 
         Exercises both the main program and a named procedure so that all
@@ -644,46 +644,46 @@ class TestQcdl:
         )
 
 
-class TestQcdlStatementStatementFeatures:
-    """Derived properties and methods on QcdlStatement."""
+class TestQCDLStatementStatementFeatures:
+    """Derived properties and methods on QCDLStatement."""
 
     # --- qubit_name ----------------------------------------------------
 
     def test_qubit_name_alias(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         assert stmt.qubit_name == "q0"
 
     def test_qubit_name_none_for_procedure_call(self):
-        stmt = QcdlStatement.model_validate({"op": "proc", "qubit": None})
+        stmt = QCDLStatement.model_validate({"op": "proc", "qubit": None})
         assert stmt.qubit_name is None
 
     # --- is_procedure_call ---------------------------------------------
 
     def test_is_procedure_call_true_when_name_none(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "my_proc", "qubit": None, "qubits": ["q0"]}
         )
         assert stmt.is_procedure_call is True
 
     def test_is_procedure_call_false_for_gate(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         assert stmt.is_procedure_call is False
 
     # --- modules -------------------------------------------------------
 
     def test_modules_from_name(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         assert stmt.modules == ["q0"]
 
     def test_modules_from_qubit_arg(self):
         """For most ops, qubit-like args are extracted into modules."""
-        stmt = QcdlStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
+        stmt = QCDLStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
         assert "q0" in stmt.modules
         assert "q1" in stmt.modules
 
     def test_modules_excludes_qubit_arg_for_comment(self):
         """For 'comment', args are opaque and must NOT be extracted."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "comment", "qubit": "q0", "args": ["q1"]}
         )
         assert stmt.modules == ["q0"]
@@ -691,28 +691,28 @@ class TestQcdlStatementStatementFeatures:
 
     def test_modules_excludes_qubit_arg_for_if(self):
         """For 'If', args are opaque."""
-        stmt = QcdlStatement.model_validate({"op": "If", "qubit": "q0", "args": ["q1"]})
+        stmt = QCDLStatement.model_validate({"op": "If", "qubit": "q0", "args": ["q1"]})
         assert stmt.modules == ["q0"]
 
     def test_modules_excludes_qubit_arg_for_c_if(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "c_if", "qubit": "q0", "args": ["q1"]}
         )
         assert stmt.modules == ["q0"]
 
     def test_modules_no_duplicates(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "h", "qubit": "q0", "qubits": ["q0"]}
         )
         assert stmt.modules.count("q0") == 1
 
     def test_modules_includes_coupler(self):
-        stmt = QcdlStatement.model_validate({"op": "cz", "qubit": "q0", "args": ["c0"]})
+        stmt = QCDLStatement.model_validate({"op": "cz", "qubit": "q0", "args": ["c0"]})
         assert "c0" in stmt.modules
 
     def test_modules_from_kwargs_qubits_key(self):
         """Qubit names under kwargs['qubits'] are included in modules."""
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "sync", "qubit": "q0", "kwargs": {"qubits": ["q1"]}}
         )
         assert "q1" in stmt.modules
@@ -721,13 +721,13 @@ class TestQcdlStatementStatementFeatures:
 
     def test_caller_qubits_is_empty_for_gate(self):
         """caller_qubits is empty for gate statements; use qubits for all modules."""
-        stmt = QcdlStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
+        stmt = QCDLStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
         assert stmt.caller_qubits == []
         assert "q0" in stmt.qubits
         assert "q1" in stmt.qubits
 
     def test_caller_qubits_proc_call_returns_raw_qubits_field(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "my_proc", "qubit": None, "caller_qubits": ["q0", "q1"]}
         )
         assert stmt.caller_qubits == ["q0", "q1"]
@@ -735,85 +735,85 @@ class TestQcdlStatementStatementFeatures:
     # --- qargs / cargs -----------------------------------------------
 
     def test_qargs_single_qubit(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         assert stmt.qargs == [0]
 
     def test_qargs_two_qubits(self):
-        stmt = QcdlStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
+        stmt = QCDLStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
         assert set(stmt.qargs) == {0, 1}
 
     def test_qargs_excludes_couplers(self):
-        stmt = QcdlStatement.model_validate({"op": "cz", "qubit": "q0", "args": ["c0"]})
+        stmt = QCDLStatement.model_validate({"op": "cz", "qubit": "q0", "args": ["c0"]})
         assert stmt.qargs == [0]
 
     def test_cargs_always_none(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         assert stmt.cargs is None
 
     # --- condition ---------------------------------------------------
 
     def test_condition_from_first_arg_for_if(self):
-        stmt = QcdlStatement.model_validate({"op": "If", "qubit": "q0", "args": [1]})
+        stmt = QCDLStatement.model_validate({"op": "If", "qubit": "q0", "args": [1]})
         assert stmt.condition == 1
 
     def test_condition_from_kwargs_for_if(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "If", "qubit": "q0", "kwargs": {"condition": 1}}
         )
         assert stmt.condition == 1
 
     def test_condition_last_arg_for_c_if(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "c_if", "qubit": "q1", "args": ["x", "q0"]}
         )
         assert stmt.condition == "q0"
 
     def test_condition_last_arg_for_c_if_else(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "c_if_else", "qubit": "q0", "args": [True]}
         )
         assert stmt.condition is True
 
     def test_condition_raises_for_non_conditional_op(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         with pytest.raises(QCDLInternalError):
             _ = stmt.condition
 
     def test_condition_raises_for_if_without_condition(self):
-        stmt = QcdlStatement.model_validate({"op": "If", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "If", "qubit": "q0"})
         with pytest.raises(QCDLInternalError):
             _ = stmt.condition
 
     # --- simple_desc -------------------------------------------------
 
     def test_simple_desc_cpu(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "cpu", "qubit": "q0", "args": ["x = 1\ny = 2"]}
         )
         assert stmt.simple_desc() == "x = 1; y = 2"
 
     def test_simple_desc_if(self):
-        stmt = QcdlStatement.model_validate({"op": "If", "qubit": "q0", "args": [1]})
+        stmt = QCDLStatement.model_validate({"op": "If", "qubit": "q0", "args": [1]})
         assert stmt.simple_desc() == "If(1)"
 
     def test_simple_desc_else_no_goto(self):
-        stmt = QcdlStatement.model_validate({"op": "Else", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "Else", "qubit": "q0"})
         assert stmt.simple_desc() == "Else"
 
     def test_simple_desc_else_with_goto(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "Else", "qubit": "q0", "kwargs": {"goto": "loop_end"}}
         )
         assert stmt.simple_desc() == "Else(goto=loop_end)"
 
     def test_simple_desc_label(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "label", "qubit": "q0", "kwargs": {"label": "loop_start"}}
         )
         assert stmt.simple_desc() == "label(loop_start)"
 
     def test_simple_desc_generic_falls_back_to_str(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         result = stmt.simple_desc()
         assert "h" in result
         assert "q0" in result
@@ -821,19 +821,19 @@ class TestQcdlStatementStatementFeatures:
     # --- __str__ -----------------------------------------------------
 
     def test_str_gate_contains_op_and_qubit(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         s = str(stmt)
         assert "h" in s
         assert "q0" in s
 
     def test_str_gate_with_arg(self):
-        stmt = QcdlStatement.model_validate({"op": "rx", "qubit": "q0", "args": [1.5]})
+        stmt = QCDLStatement.model_validate({"op": "rx", "qubit": "q0", "args": [1.5]})
         s = str(stmt)
         assert "rx" in s
         assert "1.5" in s
 
     def test_str_procedure_call(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "my_proc", "qubit": None, "caller_qubits": ["q0", "q1"]}
         )
         s = str(stmt)
@@ -844,19 +844,19 @@ class TestQcdlStatementStatementFeatures:
     # --- reassign_arg / reassign_kwarg -------------------------------
 
     def test_reassign_arg_mutates_args(self):
-        stmt = QcdlStatement.model_validate({"op": "rx", "qubit": "q0", "args": [1.5]})
+        stmt = QCDLStatement.model_validate({"op": "rx", "qubit": "q0", "args": [1.5]})
         stmt.reassign_arg(0, 2.0)
         assert stmt.args[0] == 2.0
 
     def test_reassign_kwarg_sets_new_value(self):
-        stmt = QcdlStatement.model_validate(
+        stmt = QCDLStatement.model_validate(
             {"op": "p", "qubit": "q0", "kwargs": {"theta": 1.5}}
         )
         stmt.reassign_kwarg("theta", 2.0)
         assert stmt.kwargs["theta"] == 2.0
 
     def test_reassign_kwarg_adds_new_key(self):
-        stmt = QcdlStatement.model_validate({"op": "h", "qubit": "q0"})
+        stmt = QCDLStatement.model_validate({"op": "h", "qubit": "q0"})
         stmt.reassign_kwarg("new_key", "new_val")
         assert stmt.kwargs["new_key"] == "new_val"
 

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -22,7 +22,7 @@ import pytest
 
 from dwave.gate.qcdl import (
     FixedPointRegister,
-    QcdlModule,
+    QCDLModule,
     QCDLUserError,
     Register,
     arbitrary_function,
@@ -520,7 +520,7 @@ def test_register_is_container():
     @procedure
     def inner(q, register):
         q.rx(0.123)
-        # this test handles the case where a register is a QcdlModuleContainer
+        # this test handles the case where a register is a QCDLModuleContainer
         # see https://github.com/quantumcircuits/aqumen_environment/issues/1330
         register += 1
 
@@ -554,11 +554,11 @@ def test_find_modules():
         modules = [q0]
 
         reg = Register(modules, name="reg")
-        assert next(QcdlModule.find_modules(reg)).qcdl_module_name == "q0"
-        assert next(QcdlModule.find_modules(q0)).qcdl_module_name == "q0"
-        assert next(QcdlModule.find_modules(q1)).qcdl_module_name == "q1"
+        assert next(QCDLModule.find_modules(reg)).qcdl_module_name == "q0"
+        assert next(QCDLModule.find_modules(q0)).qcdl_module_name == "q0"
+        assert next(QCDLModule.find_modules(q1)).qcdl_module_name == "q1"
         assert set(
-            [q.qcdl_module_name for q in QcdlModule.find_modules(reg, q1)]
+            [q.qcdl_module_name for q in QCDLModule.find_modules(reg, q1)]
         ) == set(["q0", "q1"])
 
     assert main()
@@ -566,7 +566,7 @@ def test_find_modules():
 
 def test_parent_proc_not_altered():
     class ModuleHider(object):
-        # this is not a QcdlModuleContainer and thus
+        # this is not a QCDLModuleContainer and thus
         # hides a module
         def __init__(self, register):
             self.register = register
@@ -575,7 +575,7 @@ def test_parent_proc_not_altered():
     def inner(q0, hider):
         q0.rx(0.123)
         # this test handles the case where something containing modules but
-        # is not a QcdlModuleContainer is passed
+        # is not a QCDLModuleContainer is passed
         # see https://github.com/quantumcircuits/aqumen_environment/issues/1330
         hider.register += 1
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 
 from dwave.gate.qcdl import QCDLUserError, Scope, print_qcdl, procedure, qcdl
-from dwave.gate.qcdl.qcdl_models import QcdlStatement
+from dwave.gate.qcdl.qcdl_models import QCDLStatement
 from dwave.gate.qcdl.utils import simplify_float
 
 
@@ -337,7 +337,7 @@ def test_one_to_all():
 
     input_qcdl = main().model_dump(exclude_unset=True)
     for stmt in input_qcdl["program"]["statements"]:
-        s = QcdlStatement.model_validate(stmt)
+        s = QCDLStatement.model_validate(stmt)
         if s.op == "one_to_all":
             assert s.qubit_name == "q0"
             assert s.kwargs["qubits"] == ["q1", "q2"]

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -14,14 +14,14 @@
 
 import itertools
 
-from dwave.gate.qcdl import QcdlModule, qcdl
-from dwave.gate.qcdl.qcdl_models import QcdlStatement
+from dwave.gate.qcdl import QCDLModule, qcdl
+from dwave.gate.qcdl.qcdl_models import QCDLStatement
 from dwave.gate.qcdl.utils import is_qubit_name
 
 
 def make_statement(qubit, op, *op_args, **op_kwargs):
     @qcdl(2)
-    def main(q0: QcdlModule, q1: QcdlModule):
+    def main(q0: QCDLModule, q1: QCDLModule):
         qcdl_kwargs = dict(
             q0=q0,
             q1=q1,
@@ -34,7 +34,7 @@ def make_statement(qubit, op, *op_args, **op_kwargs):
         getattr(q, op)(*args, **kwargs)
 
     qcdl_json = main().model_dump(exclude_unset=True)
-    return QcdlStatement.model_validate(qcdl_json["program"]["statements"][0])
+    return QCDLStatement.model_validate(qcdl_json["program"]["statements"][0])
 
 
 def test_qubits_used():
@@ -75,8 +75,8 @@ def test_conditionals():
 
 
 def test_statement_model_validates_dict():
-    """QcdlStatement can be validated from a raw dict."""
-    stmt = QcdlStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
+    """QCDLStatement can be validated from a raw dict."""
+    stmt = QCDLStatement.model_validate({"op": "cx", "qubit": "q0", "args": ["q1"]})
     assert stmt.op == "cx"
     assert stmt.qubit_name == "q0"
     assert any(m.name == "q0" for m in stmt.modules)


### PR DESCRIPTION
* Capitalize all instances of `Qcdl` in class names (e.g., `QcdlCircuit` to `QCDLCircuit`)
* Renamed the `Qcdl` class to `QCDLProgram`.