### PR TITLE
remove QCDLNotImplementedError

### DIFF
--- a/dwave/gate/qcdl/__init__.py
+++ b/dwave/gate/qcdl/__init__.py
@@ -15,7 +15,7 @@
 from . import operations
 from .components import QCDLModule, QCDLModuleContainer, Scope, procedure
 from .constants import LogicalOutcomeToInteger
-from .exceptions import QCDLInternalError, QCDLNotImplementedError, QCDLUserError
+from .exceptions import QCDLInternalError, QCDLUserError
 from .qcdl_circuit import qcdl
 from .qcdl_models import QCDLProgram, QCDLProcedureDef, QCDLStatement
 from .registers import FixedPointRegister, Register, arbitrary_function
@@ -26,7 +26,6 @@ __all__ = [
     "FixedPointRegister",
     "LogicalOutcomeToInteger",
     "QCDLInternalError",
-    "QCDLNotImplementedError",
     "QCDLUserError",
     "QCDLProgram",
     "QCDLModule",

--- a/dwave/gate/qcdl/exceptions.py
+++ b/dwave/gate/qcdl/exceptions.py
@@ -23,7 +23,3 @@ class QCDLInternalError(Exception):
 
 class QCDLRuntimeError(Exception):
     """Runtime issue with the circuit."""
-
-
-class QCDLNotImplementedError(NotImplementedError):
-    """Feature is not implemented."""


### PR DESCRIPTION
closes #66 
I don't remember why it was added in the first place and in any case, it isn't used now (we should just use the built-in one on the client, we have a different exception for server-side "not implemented").