### PR TITLE
claude identified bugs/validations

### DIFF
--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -517,11 +517,11 @@ You can also reset qubits individually.
 .. testcode::
 
     from dwave.gate.qcdl import qcdl
-    from dwave.gate.qcdl.operations import initialize
+    from dwave.gate.qcdl.operations import reset
 
     @qcdl(1)
     def reset_example(q0):
-        q0.reset()
+        reset(q0)
 
 
 .. _qcdl_basic_transpilation:
@@ -830,15 +830,15 @@ This example detects and resets a qubit if it has been erased.
 .. testcode::
 
     from dwave.gate.qcdl import qcdl
-    from dwave.gate.qcdl.operations import mced
+    from dwave.gate.qcdl.operations import mced, reset
 
     @qcdl(1)
-    def detect_erasure_example(q):
-        erased = q.Register(name="erased")
+    def detect_erasure_example(q0):
+        erased = q0.Register(name="erased")
         erased <<= 0
-        mced(q, register=erased)
-        with q.If(erased == 1):
-            q.reset()
+        mced(q0, register=erased)
+        with q0.If(erased == 1):
+            reset(q0)
 
 This example conditions on a classical register.
 
@@ -986,8 +986,9 @@ condition value used in the ``If`` statement here and in subsequent examples.
         # all qubits have a copy of the same register:
         send_register = sc.Register(name=name)
 
-        # set the register on q0 to 0 or 1
-        measure(q0, register=q0.Register(name=name))
+        # set the register on q0 to 0 or 1; alias=True reuses the memory
+        # send_register already allocated instead of redeclaring it
+        measure(q0, register=q0.Register(name=name, alias=True))
 
         # if any of the copies of the register are equal to 1, then all
         # will receive a condition of True.

--- a/dwave/gate/qcdl/components.py
+++ b/dwave/gate/qcdl/components.py
@@ -251,6 +251,7 @@ class Procedure(IndexerMixin):
         name: str,
         dtype: str,
         allow_existing: bool = False,
+        initial_value_specified: bool = False,
     ) -> None:
         """Record a register allocation, rejecting a silent re-declaration.
 
@@ -258,6 +259,11 @@ class Procedure(IndexerMixin):
         declaration of the same name on the same module is a no-op: its initial
         value never reaches the qubit. That is almost always a mistake, so it is
         reported here instead.
+
+        Re-declaring the name is allowed when the caller asked for it, but an
+        explicit initial value is still rejected: opting in to the
+        re-declaration says the existing memory is wanted, whereas giving a
+        value says the opposite, and the compiler would ignore it.
 
         This method is mostly intended for use by developers of QCDL; the
         :class:`~dwave.gate.qcdl.registers.Register` and
@@ -269,28 +275,42 @@ class Procedure(IndexerMixin):
             name: Name of the register.
             dtype: ``"int"`` or ``"float"``.
             allow_existing: If True, an existing allocation of ``name`` is
-                accepted. Set by the ``alias`` and ``ignore_reallocation``
-                arguments of a register.
+                accepted as long as no initial value was given. Set by the
+                ``alias`` and ``ignore_reallocation`` arguments of a register.
+            initial_value_specified: Whether the caller gave an initial value
+                for this register.
 
         Raises:
             :exception:`~dwave.gate.qcdl.exceptions.QCDLUserError`: If ``name``
-                is already allocated on one of ``modules`` and
-                ``allow_existing`` is False.
+                is already allocated on one of ``modules`` and either
+                ``allow_existing`` is False or an initial value was given.
         """
         for module in modules:
             allocated = self._allocated_registers.setdefault(
                 module.qcdl_module_name, {}
             )
             previous = allocated.get(name)
-            if previous is not None and not allow_existing:
+            if previous is not None and not (
+                allow_existing and not initial_value_specified
+            ):
+                if allow_existing:
+                    raise QCDLUserError(
+                        f"register {name!r} is already allocated on"
+                        f" {module.qcdl_module_name} with dtype {previous} in"
+                        f" procedure {self.name}, and the compiler keeps the"
+                        f" first allocation, so the initial value given here"
+                        f" would never reach the qubit. Re-declaring the name is"
+                        f" allowed, but giving it a value is not: drop the"
+                        f" initial value."
+                    )
                 raise QCDLUserError(
                     f"register {name!r} is already allocated on"
                     f" {module.qcdl_module_name} with dtype {previous} in"
                     f" procedure {self.name}; the compiler keeps the first"
                     f" allocation, so this one would be discarded. Reuse the"
-                    f" existing register, pick another name, pass alias=True to"
-                    f" reuse its memory, or pass ignore_reallocation=True to"
-                    f" allow the redeclaration."
+                    f" existing register, pick another name, or redeclare it"
+                    f" deliberately with alias=True or ignore_reallocation=True"
+                    f" and no initial value."
                 )
             allocated[name] = dtype
 

--- a/dwave/gate/qcdl/components.py
+++ b/dwave/gate/qcdl/components.py
@@ -134,6 +134,10 @@ class Procedure(IndexerMixin):
         # qubits in the statement are not listed in the last item in this list.
         self._exclusive_modules: list[set[str]] = []
 
+        # register names allocated in this procedure, per module, so that
+        # re-declaring one can be reported rather than silently discarded
+        self._allocated_registers: dict[str, dict[str, str]] = {}
+
         self._procedure_ended = False
 
     def to_model(self) -> QCDLProcedureDef:
@@ -240,6 +244,55 @@ class Procedure(IndexerMixin):
         module = QCDLModuleName.model_validate(module_name)
         if module not in self.modules_used:
             self.modules_used.append(module)
+
+    def register_memory_allocation(
+        self,
+        modules: Sequence[QCDLModule],
+        name: str,
+        dtype: str,
+        allow_existing: bool = False,
+    ) -> None:
+        """Record a register allocation, rejecting a silent re-declaration.
+
+        The compiler keeps the *first* allocation of a name, so a second
+        declaration of the same name on the same module is a no-op: its initial
+        value never reaches the qubit. That is almost always a mistake, so it is
+        reported here instead.
+
+        This method is mostly intended for use by developers of QCDL; the
+        :class:`~dwave.gate.qcdl.registers.Register` and
+        :class:`~dwave.gate.qcdl.registers.FixedPointRegister` classes call it
+        for you.
+
+        Args:
+            modules: Modules the register is allocated on.
+            name: Name of the register.
+            dtype: ``"int"`` or ``"float"``.
+            allow_existing: If True, an existing allocation of ``name`` is
+                accepted. Set by the ``alias`` and ``ignore_reallocation``
+                arguments of a register.
+
+        Raises:
+            :exception:`~dwave.gate.qcdl.exceptions.QCDLUserError`: If ``name``
+                is already allocated on one of ``modules`` and
+                ``allow_existing`` is False.
+        """
+        for module in modules:
+            allocated = self._allocated_registers.setdefault(
+                module.qcdl_module_name, {}
+            )
+            previous = allocated.get(name)
+            if previous is not None and not allow_existing:
+                raise QCDLUserError(
+                    f"register {name!r} is already allocated on"
+                    f" {module.qcdl_module_name} with dtype {previous} in"
+                    f" procedure {self.name}; the compiler keeps the first"
+                    f" allocation, so this one would be discarded. Reuse the"
+                    f" existing register, pick another name, pass alias=True to"
+                    f" reuse its memory, or pass ignore_reallocation=True to"
+                    f" allow the redeclaration."
+                )
+            allocated[name] = dtype
 
     @property
     def expression_queue(self) -> list | None:
@@ -1230,7 +1283,9 @@ class QCDLModuleContainer(QCDLModuleContainerBase):
                     sc = Scope(q0, q1)
                     r1 = sc.Register(name="r1")
                     h(q0)
-                    measure(q0, register=q0.Register(name="r1"))
+                    # alias=True reuses the memory r1 already allocated, so the
+                    # outcome is stored on q0 only rather than mirrored
+                    measure(q0, register=q0.Register(name="r1", alias=True))
                     sc.all_to_all(send=r1==1, reduce_op="&")
                     with sc.If(None):
                         x(q1)
@@ -1664,6 +1719,54 @@ class QCDLModuleContainer(QCDLModuleContainerBase):
         return shape, table_row
 
 
+def _as_modules(qubits: Any, argument: str) -> tuple[list[QCDLModule], int | None]:
+    """Normalize a group of qubits into modules and a scope id.
+
+    Accepts a :class:`.Scope`, a single :class:`.QCDLModule`, or a sequence of
+    either, so that a caller does not have to know which of those an API wants.
+
+    Args:
+        qubits: The group of qubits.
+        argument: Name of the parameter being normalized, for error messages.
+
+    Raises:
+        :exception:`~dwave.gate.qcdl.exceptions.QCDLUserError`: If no qubits
+            could be found in ``qubits``.
+
+    Returns:
+        The modules, deduplicated and in order, and the ``scope_id`` if the
+        group carried one.
+    """
+    if isinstance(qubits, QCDLModuleContainer):
+        modules = list(qubits.qcdl_modules)
+        if not modules:
+            raise QCDLUserError(f"{argument} {qubits} does not hold any qubits")
+        return modules, qubits.scope_id
+
+    if isinstance(qubits, str) or not isinstance(qubits, Sequence):
+        raise QCDLUserError(
+            f"{argument} must be a Scope, a QCDLModule, or a sequence of them,"
+            f" not {type(qubits).__name__} ({qubits!r})"
+        )
+
+    # deduplicate by name while preserving order
+    by_name: dict[str, QCDLModule] = {}
+    for item in qubits:
+        if not isinstance(item, QCDLModuleContainer):
+            raise QCDLUserError(
+                f"every item in {argument} must be a Scope or a QCDLModule, not"
+                f" {type(item).__name__} ({item!r})"
+            )
+        for module in item.qcdl_modules:
+            by_name[module.qcdl_module_name] = module
+
+    if not by_name:
+        raise QCDLUserError(f"{argument} does not hold any qubits")
+
+    # a bare sequence has no identity of its own, so it carries no scope_id
+    return list(by_name.values()), None
+
+
 class QCDLModule(QCDLModuleContainer):
     """Wrapper around a :class:`.Procedure` instance.
 
@@ -1834,7 +1937,10 @@ class QCDLModule(QCDLModuleContainer):
         return f"{self.qcdl_module_name}.signal"
 
     def one_to_all(
-        self, destinations: Scope, send: RegisterExpression, **kwargs: Any
+        self,
+        destinations: Scope | QCDLModule | Sequence[QCDLModule],
+        send: RegisterExpression,
+        **kwargs: Any,
     ) -> None:
         """Send a bit from one qubit to a :class:`~dwave.gate.qcdl.Scope` of
         other qubits.
@@ -1843,19 +1949,25 @@ class QCDLModule(QCDLModuleContainer):
         examples of signals.
 
         Args:
-            destinations: The scope of all qubits to send the message to. The
-                bit is placed on each qubit's branch condition to be used in a
-                conditional statement.
+            destinations: The qubits to send the message to, as a
+                :class:`~dwave.gate.qcdl.Scope`, a single
+                :class:`~dwave.gate.qcdl.QCDLModule`, or a sequence of either.
+                The bit is placed on each qubit's branch condition to be used in
+                a conditional statement. Statements are tagged with the
+                ``scope_id`` only when a :class:`~dwave.gate.qcdl.Scope` is
+                passed.
             send: The expression to compute the bit on the sender.
 
         Raises:
-            :exception:`ValueError`: If the module has more than one qubit.
+            :exception:`~dwave.gate.qcdl.exceptions.QCDLUserError`: If
+                ``destinations`` does not hold any qubits.
         """
+        modules, scope_id = _as_modules(destinations, "destinations")
         self._multi_qubit_statement(
             "one_to_all",
             send=send,
-            qubits=destinations.qcdl_modules,
-            scope_id=destinations.scope_id,
+            qubits=modules,
+            scope_id=scope_id,
             **kwargs,
         )
 

--- a/dwave/gate/qcdl/operations.py
+++ b/dwave/gate/qcdl/operations.py
@@ -124,58 +124,58 @@ def _is_qubit(value: Any) -> bool:
     return getattr(value, "_is_qcdl_module", False) is True
 
 
-def _validate_qubit_args(distinct: bool = False) -> Callable[[_Operation], _Operation]:
+def _validate_qubit_args(operation: _Operation) -> _Operation:
     """Check the qubit arguments of an operation before it is recorded.
 
     Without this, a non-qubit argument surfaces much later as an
     ``AttributeError`` naming an internal attribute, and a two-qubit gate given
     the same qubit twice builds cleanly and is only rejected by the service.
 
+    Whether the qubits have to be distinct follows from the signature: each
+    named qubit parameter is a separate role in the operation, so two of them
+    may not be the same module, whereas a ``*qubits`` parameter is a set of
+    qubits to act on, where a repeat is harmless.
+
     Args:
-        distinct: If True, the operation's qubits must all be different
-            modules, as they must be for a two-qubit gate.
+        operation: The operation to wrap.
 
     Returns:
-        A decorator for an operation in this module.
+        The operation, wrapped in its argument check.
     """
+    signature = inspect.signature(operation)
+    names: list[str] = []
+    variadic: str | None = None
+    for name, parameter in signature.parameters.items():
+        if parameter.annotation is not QCDLModule:
+            continue
+        if parameter.kind is parameter.VAR_POSITIONAL:
+            variadic = name
+        else:
+            names.append(name)
 
-    def decorate(operation: _Operation) -> _Operation:
-        signature = inspect.signature(operation)
-        names: list[str] = []
-        variadic: str | None = None
-        for name, parameter in signature.parameters.items():
-            if parameter.annotation is not QCDLModule:
-                continue
-            if parameter.kind is parameter.VAR_POSITIONAL:
-                variadic = name
-            else:
-                names.append(name)
+    distinct = len(names) > 1
 
-        @functools.wraps(operation)
-        def wrapper(*args: Any, **kwargs: Any) -> None:
-            try:
-                bound = signature.bind(*args, **kwargs)
-            except TypeError:
-                # let python report the arity error against the real signature
-                return operation(*args, **kwargs)
-
-            qubits = [
-                (name, bound.arguments[name])
-                for name in names
-                if name in bound.arguments
-            ]
-            if variadic is not None:
-                qubits += [
-                    (f"{variadic}[{index}]", qubit)
-                    for index, qubit in enumerate(bound.arguments.get(variadic, ()))
-                ]
-
-            _check_qubit_args(operation.__name__, qubits, distinct=distinct)
+    @functools.wraps(operation)
+    def wrapper(*args: Any, **kwargs: Any) -> None:
+        try:
+            bound = signature.bind(*args, **kwargs)
+        except TypeError:
+            # let python report the arity error against the real signature
             return operation(*args, **kwargs)
 
-        return wrapper  # type: ignore[return-value]
+        qubits = [
+            (name, bound.arguments[name]) for name in names if name in bound.arguments
+        ]
+        if variadic is not None:
+            qubits += [
+                (f"{variadic}[{index}]", qubit)
+                for index, qubit in enumerate(bound.arguments.get(variadic, ()))
+            ]
 
-    return decorate
+        _check_qubit_args(operation.__name__, qubits, distinct=distinct)
+        return operation(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
 
 
 def _check_qubit_args(
@@ -217,7 +217,7 @@ def _check_qubit_args(
 # Operations
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def initialize(*qubits: QCDLModule) -> None:
     """Initialize qubits.
 
@@ -236,7 +236,7 @@ def initialize(*qubits: QCDLModule) -> None:
     qubits[0].initialize(*qubits[1:])
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def reset(qubit: QCDLModule) -> None:
     r"""Reset a single qubit to :math:`|0\rangle`.
 
@@ -265,7 +265,7 @@ def reset(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(qubit.qcdl_module_name, "reset", None, None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def barrier(*qubits: QCDLModule, label: str | None = None) -> None:
     """Place a barrier on qubits.
 
@@ -318,7 +318,7 @@ def barrier(*qubits: QCDLModule, label: str | None = None) -> None:
     qubits[0].barrier(*qubits[1:], **kwargs)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def measure(
     qubit: QCDLModule,
     log: bool = True,
@@ -375,7 +375,7 @@ def measure(
         implementations.mirror_measurement_register(sender=qubit, register=register)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def mced(qubit: QCDLModule, register: Register, mirror: bool = True) -> None:
     """Perform a non-destructive mid-circuit erasure detection (MCED).
 
@@ -416,7 +416,7 @@ def mced(qubit: QCDLModule, register: Register, mirror: bool = True) -> None:
 # 1 Qubit Non-Parameterized Gates
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def x(qubit: QCDLModule) -> None:
     """`X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.XGate>`_
     gate.
@@ -441,7 +441,7 @@ def x(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "x", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def sx(qubit: QCDLModule) -> None:
     r"""`Square-root of X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SXGate>`_
     (:math:`\sqrt X`) gate.
@@ -466,7 +466,7 @@ def sx(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "sx", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def sxdg(qubit: QCDLModule) -> None:
     r"""`Square-root of X adjoint <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SXdgGate>`_
     (:math:`\sqrt X^\dagger`) gate.
@@ -494,7 +494,7 @@ def sxdg(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "sxdg", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def y(qubit: QCDLModule) -> None:
     """`Y <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.YGate>`_
     gate.
@@ -519,7 +519,7 @@ def y(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "y", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def sy(qubit: QCDLModule) -> None:
     r"""SQRT of Y gate.
     TODO it's not a qiskit gate
@@ -544,7 +544,7 @@ def sy(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, np.pi / 2], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def sydg(qubit: QCDLModule) -> None:
     r"""SQRT of Y_adjoint gate.
     TODO it's not a qiskit gate
@@ -569,7 +569,7 @@ def sydg(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, -np.pi / 2], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def z(qubit: QCDLModule) -> None:
     """`Z <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.ZGate>`_
     gate.
@@ -594,7 +594,7 @@ def z(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "z", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def s(qubit: QCDLModule) -> None:
     """`S <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SGate>`_
     gate.
@@ -619,7 +619,7 @@ def s(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "s", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def sdg(qubit: QCDLModule) -> None:
     r"""`S-adjoint <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SdgGate>`_
     (:math:`S^\dagger`) gate.
@@ -645,7 +645,7 @@ def sdg(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "sdg", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def t(qubit: QCDLModule) -> None:
     r"""`T <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.TGate>`_
     (:math:`\sqrt[4]{Z}`) gate.
@@ -670,7 +670,7 @@ def t(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "t", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def tdg(qubit: QCDLModule) -> None:
     r"""`T-adjoint <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.TdgGate>`_
     (:math:`T^\dagger`) gate.
@@ -695,7 +695,7 @@ def tdg(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "tdg", [qubit], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def h(qubit: QCDLModule) -> None:
     """`Hadamard <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.HGate>`_
     gate.
@@ -723,7 +723,7 @@ def h(qubit: QCDLModule) -> None:
 # 1 Qubit Parameterized Gates
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def rx(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `X-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RXGate>`_
@@ -751,7 +751,7 @@ def rx(qubit: QCDLModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "rx", [qubit, phi], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def ry(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `Y-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RYGate>`_
@@ -779,7 +779,7 @@ def ry(qubit: QCDLModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, phi], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def rz(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `Z-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RZGate>`_
@@ -807,7 +807,7 @@ def rz(qubit: QCDLModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "rz", [qubit, phi], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def p(qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Phase <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.PhaseGate>`_
     gate.
@@ -834,7 +834,7 @@ def p(qubit: QCDLModule, theta: AngleType) -> None:
     qubit.procedure.add_statement(None, "p", [qubit, theta], None)
 
 
-@_validate_qubit_args()
+@_validate_qubit_args
 def u(qubit: QCDLModule, theta: AngleType, phi: AngleType, lam: AngleType) -> None:
     r"""Single-qubit
     `generic U <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.UGate>`_
@@ -866,7 +866,7 @@ def u(qubit: QCDLModule, theta: AngleType, phi: AngleType, lam: AngleType) -> No
 # 2 Qubit Non-Parameterized Gates
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def swap(qubit1: QCDLModule, qubit2: QCDLModule) -> None:
     """`Swap <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SwapGate>`_
     gate.
@@ -895,7 +895,7 @@ def swap(qubit1: QCDLModule, qubit2: QCDLModule) -> None:
     qubit1.procedure.add_statement(None, "swap", [qubit1, qubit2], None)
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def cx(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CXGate>`_
     gate.
@@ -924,7 +924,7 @@ def cx(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     )
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def cy(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-Y <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CYGate>`_
     gate.
@@ -953,7 +953,7 @@ def cy(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     )
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def cz(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-Z <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CZGate>`_
     gate.
@@ -985,7 +985,7 @@ def cz(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
 # 2 Qubit Parameterized Gates
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def crx(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RX <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRXGate>`_
     gate.
@@ -1016,7 +1016,7 @@ def crx(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -
     )
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def cry(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RY <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRYGate>`_
     gate.
@@ -1047,7 +1047,7 @@ def cry(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -
     )
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def crz(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RZ <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRZGate>`_
     gate.
@@ -1078,7 +1078,7 @@ def crz(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -
     )
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def cp(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-Phase <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CPhaseGate>`_
     gate.
@@ -1109,7 +1109,7 @@ def cp(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) ->
     )
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def cu(
     control_qubit: QCDLModule,
     target_qubit: QCDLModule,
@@ -1152,7 +1152,7 @@ def cu(
     )
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def rxx(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `XX-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RXXGate>`_
@@ -1181,7 +1181,7 @@ def rxx(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     qubit1.procedure.add_statement(None, "rxx", [qubit1, qubit2, theta], None)
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def ryy(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `YY-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RYYGate>`_
@@ -1210,7 +1210,7 @@ def ryy(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     qubit1.procedure.add_statement(None, "ryy", [qubit1, qubit2, theta], None)
 
 
-@_validate_qubit_args(distinct=True)
+@_validate_qubit_args
 def rzz(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `ZZ-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RZZGate>`_

--- a/dwave/gate/qcdl/operations.py
+++ b/dwave/gate/qcdl/operations.py
@@ -55,8 +55,9 @@ Examples:
         qcdl_program = qcdl_module_methods()
 """
 
-from collections.abc import Sequence
-from typing import Any, TypeAlias
+import functools
+import inspect
+from typing import Any, Callable, TypeAlias, TypeVar
 
 import numpy as np
 
@@ -67,9 +68,155 @@ from .registers import FixedPointRegister, Register
 
 AngleType: TypeAlias = float | FixedPointRegister
 
+# Everything else in this module, including the names imported above, is an
+# implementation detail: ``from dwave.gate.qcdl.operations import *`` brings in
+# the operations only.
+__all__ = [
+    "AngleType",
+    "barrier",
+    "cp",
+    "crx",
+    "cry",
+    "crz",
+    "cu",
+    "cx",
+    "cy",
+    "cz",
+    "h",
+    "initialize",
+    "mced",
+    "measure",
+    "p",
+    "reset",
+    "rx",
+    "rxx",
+    "ry",
+    "ryy",
+    "rz",
+    "rzz",
+    "s",
+    "sdg",
+    "swap",
+    "sx",
+    "sy",
+    "sydg",
+    "t",
+    "tdg",
+    "u",
+    "x",
+    "y",
+    "z",
+]
+
+_Operation = TypeVar("_Operation", bound=Callable[..., None])
+
+
+def _is_qubit(value: Any) -> bool:
+    """Whether ``value`` can carry a QCDL instruction.
+
+    A machine may supply its own module type rather than a
+    :class:`~dwave.gate.qcdl.QCDLModule`, so this also accepts anything that
+    identifies itself as a QCDL module.
+    """
+    if isinstance(value, QCDLModule):
+        return True
+    return getattr(value, "_is_qcdl_module", False) is True
+
+
+def _validate_qubit_args(distinct: bool = False) -> Callable[[_Operation], _Operation]:
+    """Check the qubit arguments of an operation before it is recorded.
+
+    Without this, a non-qubit argument surfaces much later as an
+    ``AttributeError`` naming an internal attribute, and a two-qubit gate given
+    the same qubit twice builds cleanly and is only rejected by the service.
+
+    Args:
+        distinct: If True, the operation's qubits must all be different
+            modules, as they must be for a two-qubit gate.
+
+    Returns:
+        A decorator for an operation in this module.
+    """
+
+    def decorate(operation: _Operation) -> _Operation:
+        signature = inspect.signature(operation)
+        names: list[str] = []
+        variadic: str | None = None
+        for name, parameter in signature.parameters.items():
+            if parameter.annotation is not QCDLModule:
+                continue
+            if parameter.kind is parameter.VAR_POSITIONAL:
+                variadic = name
+            else:
+                names.append(name)
+
+        @functools.wraps(operation)
+        def wrapper(*args: Any, **kwargs: Any) -> None:
+            try:
+                bound = signature.bind(*args, **kwargs)
+            except TypeError:
+                # let python report the arity error against the real signature
+                return operation(*args, **kwargs)
+
+            qubits = [
+                (name, bound.arguments[name])
+                for name in names
+                if name in bound.arguments
+            ]
+            if variadic is not None:
+                qubits += [
+                    (f"{variadic}[{index}]", qubit)
+                    for index, qubit in enumerate(bound.arguments.get(variadic, ()))
+                ]
+
+            _check_qubit_args(operation.__name__, qubits, distinct=distinct)
+            return operation(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorate
+
+
+def _check_qubit_args(
+    op: str, qubits: list[tuple[str, Any]], distinct: bool = False
+) -> None:
+    """Validate the qubit arguments collected for operation ``op``.
+
+    Args:
+        op: Name of the operation, used in error messages.
+        qubits: Pairs of parameter name and the value passed for it.
+        distinct: If True, require every qubit to be a different module.
+
+    Raises:
+        :exception:`~dwave.gate.qcdl.exceptions.QCDLUserError`: If an argument
+            is not a qubit, or if ``distinct`` and a qubit is repeated.
+    """
+    for name, value in qubits:
+        if not _is_qubit(value):
+            raise QCDLUserError(
+                f"{op}() parameter {name!r} must be a qubit, not"
+                f" {type(value).__name__} ({value!r}); the qcdl decorator passes"
+                f" the qubits of a circuit in as its q0, q1, ... arguments"
+            )
+
+    if not distinct:
+        return
+
+    used: dict[str, str] = {}
+    for name, value in qubits:
+        module = value.qcdl_module_name
+        if module in used:
+            raise QCDLUserError(
+                f"{op}() needs distinct qubits, but parameters {used[module]!r}"
+                f" and {name!r} are both {module}"
+            )
+        used[module] = name
+
+
 # Operations
 
 
+@_validate_qubit_args()
 def initialize(*qubits: QCDLModule) -> None:
     """Initialize qubits.
 
@@ -88,6 +235,36 @@ def initialize(*qubits: QCDLModule) -> None:
     qubits[0].initialize(*qubits[1:])
 
 
+@_validate_qubit_args()
+def reset(qubit: QCDLModule) -> None:
+    r"""Reset a single qubit to :math:`|0\rangle`.
+
+    Unlike :func:`initialize`, which loops until every qubit in the program is
+    reset, this operation acts on one qubit and has deterministic duration, so
+    it can be used inside a conditional branch.
+
+    Args:
+        qubit: Qubit to reset.
+
+    Examples:
+
+        .. testcode::
+
+            from dwave.gate.qcdl import qcdl
+            from dwave.gate.qcdl.operations import measure, reset, x
+
+            @qcdl(1)
+            def reset_gate(q0):
+                x(q0)
+                reset(q0)
+                measure(q0)
+
+            qcdl_program = reset_gate()
+    """
+    qubit.procedure.add_statement(qubit.qcdl_module_name, "reset", None, None)
+
+
+@_validate_qubit_args()
 def barrier(*qubits: QCDLModule, label: str | None = None) -> None:
     """Place a barrier on qubits.
 
@@ -140,6 +317,7 @@ def barrier(*qubits: QCDLModule, label: str | None = None) -> None:
     qubits[0].barrier(*qubits[1:], **kwargs)
 
 
+@_validate_qubit_args()
 def measure(
     qubit: QCDLModule,
     log: bool = True,
@@ -196,6 +374,7 @@ def measure(
         implementations.mirror_measurement_register(sender=qubit, register=register)
 
 
+@_validate_qubit_args()
 def mced(qubit: QCDLModule, register: Register, mirror: bool = True) -> None:
     """Perform a non-destructive mid-circuit erasure detection (MCED).
 
@@ -236,6 +415,7 @@ def mced(qubit: QCDLModule, register: Register, mirror: bool = True) -> None:
 # 1 Qubit Non-Parameterized Gates
 
 
+@_validate_qubit_args()
 def x(qubit: QCDLModule) -> None:
     """`X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.XGate>`_
     gate.
@@ -260,6 +440,7 @@ def x(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "x", [qubit], None)
 
 
+@_validate_qubit_args()
 def sx(qubit: QCDLModule) -> None:
     r"""`Square-root of X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SXGate>`_
     (:math:`\sqrt X`) gate.
@@ -284,6 +465,7 @@ def sx(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "sx", [qubit], None)
 
 
+@_validate_qubit_args()
 def y(qubit: QCDLModule) -> None:
     """`Y <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.YGate>`_
     gate.
@@ -308,6 +490,7 @@ def y(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "y", [qubit], None)
 
 
+@_validate_qubit_args()
 def sy(qubit: QCDLModule) -> None:
     r"""SQRT of Y gate.
     TODO it's not a qiskit gate
@@ -332,6 +515,7 @@ def sy(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, np.pi / 2], None)
 
 
+@_validate_qubit_args()
 def sydg(qubit: QCDLModule) -> None:
     r"""SQRT of Y_adjoint gate.
     TODO it's not a qiskit gate
@@ -356,6 +540,7 @@ def sydg(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, -np.pi / 2], None)
 
 
+@_validate_qubit_args()
 def z(qubit: QCDLModule) -> None:
     """`Z <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.ZGate>`_
     gate.
@@ -380,6 +565,7 @@ def z(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "z", [qubit], None)
 
 
+@_validate_qubit_args()
 def s(qubit: QCDLModule) -> None:
     """`S <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SGate>`_
     gate.
@@ -404,6 +590,7 @@ def s(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "s", [qubit], None)
 
 
+@_validate_qubit_args()
 def sdg(qubit: QCDLModule) -> None:
     r"""`S-adjoint <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SdgGate>`_
     (:math:`S^\dagger`) gate.
@@ -429,6 +616,7 @@ def sdg(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "sdg", [qubit], None)
 
 
+@_validate_qubit_args()
 def t(qubit: QCDLModule) -> None:
     r"""`T <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.TGate>`_
     (:math:`\sqrt[4]{Z}`) gate.
@@ -453,6 +641,7 @@ def t(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "t", [qubit], None)
 
 
+@_validate_qubit_args()
 def tdg(qubit: QCDLModule) -> None:
     r"""`T-adjoint <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.TdgGate>`_
     (:math:`T^\dagger`) gate.
@@ -477,6 +666,7 @@ def tdg(qubit: QCDLModule) -> None:
     qubit.procedure.add_statement(None, "tdg", [qubit], None)
 
 
+@_validate_qubit_args()
 def h(qubit: QCDLModule) -> None:
     """`Hadamard <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.HGate>`_
     gate.
@@ -504,6 +694,7 @@ def h(qubit: QCDLModule) -> None:
 # 1 Qubit Parameterized Gates
 
 
+@_validate_qubit_args()
 def rx(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `X-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RXGate>`_
@@ -531,6 +722,7 @@ def rx(qubit: QCDLModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "rx", [qubit, phi], None)
 
 
+@_validate_qubit_args()
 def ry(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `Y-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RYGate>`_
@@ -558,6 +750,7 @@ def ry(qubit: QCDLModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "ry", [qubit, phi], None)
 
 
+@_validate_qubit_args()
 def rz(qubit: QCDLModule, phi: AngleType) -> None:
     r"""Single-qubit
     `Z-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RZGate>`_
@@ -585,6 +778,7 @@ def rz(qubit: QCDLModule, phi: AngleType) -> None:
     qubit.procedure.add_statement(None, "rz", [qubit, phi], None)
 
 
+@_validate_qubit_args()
 def p(qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Phase <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.PhaseGate>`_
     gate.
@@ -611,6 +805,7 @@ def p(qubit: QCDLModule, theta: AngleType) -> None:
     qubit.procedure.add_statement(None, "p", [qubit, theta], None)
 
 
+@_validate_qubit_args()
 def u(qubit: QCDLModule, theta: AngleType, phi: AngleType, lam: AngleType) -> None:
     r"""Single-qubit
     `generic U <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.UGate>`_
@@ -642,6 +837,7 @@ def u(qubit: QCDLModule, theta: AngleType, phi: AngleType, lam: AngleType) -> No
 # 2 Qubit Non-Parameterized Gates
 
 
+@_validate_qubit_args(distinct=True)
 def swap(qubit1: QCDLModule, qubit2: QCDLModule) -> None:
     """`Swap <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SwapGate>`_
     gate.
@@ -670,6 +866,7 @@ def swap(qubit1: QCDLModule, qubit2: QCDLModule) -> None:
     qubit1.procedure.add_statement(None, "swap", [qubit1, qubit2], None)
 
 
+@_validate_qubit_args(distinct=True)
 def cx(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-X <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CXGate>`_
     gate.
@@ -698,6 +895,7 @@ def cx(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     )
 
 
+@_validate_qubit_args(distinct=True)
 def cy(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-Y <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CYGate>`_
     gate.
@@ -726,6 +924,7 @@ def cy(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     )
 
 
+@_validate_qubit_args(distinct=True)
 def cz(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
     """`Controlled-Z <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CZGate>`_
     gate.
@@ -757,6 +956,7 @@ def cz(control_qubit: QCDLModule, target_qubit: QCDLModule) -> None:
 # 2 Qubit Parameterized Gates
 
 
+@_validate_qubit_args(distinct=True)
 def crx(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RX <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRXGate>`_
     gate.
@@ -787,6 +987,7 @@ def crx(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -
     )
 
 
+@_validate_qubit_args(distinct=True)
 def cry(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RY <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRYGate>`_
     gate.
@@ -817,6 +1018,7 @@ def cry(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -
     )
 
 
+@_validate_qubit_args(distinct=True)
 def crz(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-RZ <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CRZGate>`_
     gate.
@@ -847,6 +1049,7 @@ def crz(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -
     )
 
 
+@_validate_qubit_args(distinct=True)
 def cp(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) -> None:
     r"""`Controlled-Phase <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.CPhaseGate>`_
     gate.
@@ -877,6 +1080,7 @@ def cp(control_qubit: QCDLModule, target_qubit: QCDLModule, theta: AngleType) ->
     )
 
 
+@_validate_qubit_args(distinct=True)
 def cu(
     control_qubit: QCDLModule,
     target_qubit: QCDLModule,
@@ -919,6 +1123,7 @@ def cu(
     )
 
 
+@_validate_qubit_args(distinct=True)
 def rxx(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `XX-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RXXGate>`_
@@ -947,6 +1152,7 @@ def rxx(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     qubit1.procedure.add_statement(None, "rxx", [qubit1, qubit2, theta], None)
 
 
+@_validate_qubit_args(distinct=True)
 def ryy(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `YY-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RYYGate>`_
@@ -975,6 +1181,7 @@ def ryy(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     qubit1.procedure.add_statement(None, "ryy", [qubit1, qubit2, theta], None)
 
 
+@_validate_qubit_args(distinct=True)
 def rzz(qubit1: QCDLModule, qubit2: QCDLModule, theta: AngleType) -> None:
     r"""Two-qubit
     `ZZ-axis rotation <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.RZZGate>`_

--- a/dwave/gate/qcdl/operations.py
+++ b/dwave/gate/qcdl/operations.py
@@ -98,6 +98,7 @@ __all__ = [
     "sdg",
     "swap",
     "sx",
+    "sxdg",
     "sy",
     "sydg",
     "t",
@@ -463,6 +464,34 @@ def sx(qubit: QCDLModule) -> None:
             qcdl_program = sx_gate()
     """
     qubit.procedure.add_statement(None, "sx", [qubit], None)
+
+
+@_validate_qubit_args()
+def sxdg(qubit: QCDLModule) -> None:
+    r"""`Square-root of X adjoint <https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.SXdgGate>`_
+    (:math:`\sqrt X^\dagger`) gate.
+
+    The inverse of the :func:`.sx` gate.
+
+    Args:
+        qubit: Qubit on which to apply the gate.
+
+    Examples:
+
+        .. testcode::
+
+            from dwave.gate.qcdl import qcdl
+            from dwave.gate.qcdl.operations import measure, sx, sxdg
+
+            @qcdl(1)
+            def sxdg_gate(q0):
+                sx(q0)
+                sxdg(q0)        # returns the qubit to its initial state
+                measure(q0)
+
+            qcdl_program = sxdg_gate()
+    """
+    qubit.procedure.add_statement(None, "sxdg", [qubit], None)
 
 
 @_validate_qubit_args()

--- a/dwave/gate/qcdl/qcdl_circuit.py
+++ b/dwave/gate/qcdl/qcdl_circuit.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import functools
 import inspect
 import logging
+import numbers
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from typing import Any, Callable, Literal, TypeAlias, overload, Protocol
@@ -551,6 +552,116 @@ def _get_fspec(f: Any) -> tuple[list[str], str | None]:
     return fspec.args, f_keywords
 
 
+def _validate_num_qubits(num_qubits: Any) -> None:
+    """Check the ``num_qubits`` argument of the :func:`qcdl` decorator.
+
+    Raises:
+        :exception:`~dwave.gate.qcdl.exceptions.QCDLUserError`: If
+            ``num_qubits`` could not generate at least one qubit.
+    """
+    if callable(num_qubits):
+        raise QCDLUserError(
+            f"the qcdl decorator must be called, so decorate"
+            f" {getattr(num_qubits, '__name__', num_qubits)} with @qcdl() or"
+            f" @qcdl(num_qubits) rather than with a bare @qcdl"
+        )
+    if isinstance(num_qubits, bool) or not isinstance(num_qubits, numbers.Integral):
+        raise QCDLUserError(
+            f"num_qubits must be an integer, not {num_qubits!r} of type"
+            f" {type(num_qubits).__name__}"
+        )
+    if num_qubits < 1:
+        raise QCDLUserError(
+            f"num_qubits must be at least 1, not {num_qubits}; a program needs"
+            f" at least one qubit"
+        )
+
+
+def _unfilled_parameters(
+    f: Any, args: Sequence[Any], kwarg_names: Iterable[str]
+) -> list[str]:
+    """Required parameters of ``f`` that this call would leave unbound.
+
+    Args:
+        f: The decorated function.
+        args: Positional arguments the caller supplied.
+        kwarg_names: Names of the keyword arguments the call will supply.
+
+    Returns:
+        Parameter names with no value and no default, in declaration order.
+    """
+    try:
+        parameters = inspect.signature(f).parameters.values()
+    except (TypeError, ValueError):
+        # a callable we can not introspect; let python report the call itself
+        return []
+
+    positional_kinds = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    positional = [p for p in parameters if p.kind in positional_kinds]
+    consumed = {p.name for p in positional[: len(args)]}
+    consumed.update(kwarg_names)
+
+    return [
+        p.name
+        for p in parameters
+        if p.default is inspect.Parameter.empty
+        and p.kind in positional_kinds + (inspect.Parameter.KEYWORD_ONLY,)
+        and p.name not in consumed
+    ]
+
+
+def _unfilled_parameters_error(
+    f_name: str,
+    missing: Sequence[str],
+    supplied: Iterable[str],
+    num_qubits: int | None,
+    from_environment: bool,
+) -> TypeError:
+    """Build the error for an entry point whose parameters were not all filled.
+
+    The decorator injects qubits by *name*, so a mistyped or differently named
+    parameter silently receives nothing. Python's own message for that names
+    only the parameter, which gives no hint that qubits are involved.
+    """
+    plural = "" if len(missing) == 1 else "s"
+    message = (
+        f"{f_name}() missing {len(missing)} required positional argument"
+        f"{plural}: {', '.join(repr(name) for name in missing)}."
+    )
+
+    if from_environment:
+        source = "the environment"
+    elif num_qubits is not None:
+        source = f"@qcdl({num_qubits})"
+    else:
+        source = "@qcdl()"
+
+    supplied_names = sorted(supplied, key=lambda name: (len(name), name))
+    message += (
+        f" The qcdl decorator injects qubits as keyword arguments named q<N>"
+        f" (q0, q1, ...), and {source} supplied"
+        f" {', '.join(supplied_names) if supplied_names else 'none'}."
+    )
+
+    if any(is_qubit_or_coupler_name(name) for name in missing):
+        message += (
+            " Raise num_qubits to cover the missing qubits, or drop the"
+            " parameters for them."
+        )
+    else:
+        matches = "does not match" if len(missing) == 1 else "do not match"
+        message += (
+            f" Parameter{plural} {', '.join(repr(name) for name in missing)}"
+            f" {matches} that pattern, so no qubit was injected: rename to"
+            f" q0, q1, ..., add a default value, or pass a value explicitly."
+        )
+
+    return TypeError(message)
+
+
 QCDLV2: TypeAlias = str
 """Display-oriented QCDL string representation returned by @qcdl when
 ``to_qcdlv2=True``.
@@ -628,7 +739,9 @@ def qcdl(
             of qubits, infers qubits from the signature of the decorated
             function: any ``q<N>`` arguments, where ``<N>`` is an integer, are
             considered qubits. Generated qubits are passed in to the decorated
-            function through keyword arguments.
+            function through keyword arguments, so unless the decorated function
+            accepts ``**kwargs``, it must declare a ``q<N>`` parameter for each
+            generated qubit.
         environment: Environment. The number of qubits supplied is the full set
             supported by the environment. This parameter is intended for use by
             developers of QCDL.
@@ -684,6 +797,9 @@ def qcdl(
 
     """
 
+    if num_qubits is not None:
+        _validate_num_qubits(num_qubits)
+
     def decorator(f: QCDLSource) -> Callable[..., QCDLProgram | QCDLV2]:
         @functools.wraps(f)
         def wrapper(*args: Any, **kwargs: Any) -> QCDLProgram | QCDLV2:
@@ -731,6 +847,39 @@ def qcdl(
 
             # kwargs may include modules/systems the user has already created
             merged_kwargs = module_kwargs | kwargs
+
+            # Qubits reach the decorated function by name, so a parameter whose
+            # name is not a q<N> gets nothing. Report that (and any qubit this
+            # signature has no room for) before running the function, so the
+            # failure names the rule instead of an unbound parameter.
+            filled = (
+                set(merged_kwargs)
+                if f_keywords
+                else set(merged_kwargs) & set(f_args)
+            )
+            missing = _unfilled_parameters(f, args, filled)
+            if missing:
+                raise _unfilled_parameters_error(
+                    getattr(f, "__name__", "circuit"),
+                    missing,
+                    module_kwargs,
+                    num_qubits,
+                    from_environment=bool(_env),
+                )
+
+            if num_qubits is not None and not _env and not f_keywords:
+                dropped = [q for q in module_kwargs if q not in f_args]
+                if dropped:
+                    raise QCDLUserError(
+                        f"@qcdl({num_qubits}) generates"
+                        f" {', '.join(module_kwargs)} but"
+                        f" {getattr(f, '__name__', 'the decorated function')}()"
+                        f" has no parameter for {', '.join(dropped)}, so"
+                        f" {'they' if len(dropped) > 1 else 'it'} would be"
+                        f" dropped from the program; declare a parameter for"
+                        f" every generated qubit, lower num_qubits, or accept"
+                        f" **kwargs"
+                    )
 
             if machine:
                 # let the machine configure the procedure and any other setup it

--- a/dwave/gate/qcdl/registers.py
+++ b/dwave/gate/qcdl/registers.py
@@ -257,6 +257,15 @@ class RegisterInitializerMixin:
             name, initial_value=initial_value, length=length, dtype=dtype, signed=signed
         )
 
+        # An alias deliberately names memory that already exists, and
+        # ignore_reallocation is the documented opt out.
+        modules[0].procedure.register_memory_allocation(
+            modules,
+            name,
+            dtype,
+            allow_existing=alias is True or ignore_reallocation,
+        )
+
         if alias is not True:
             # use alias=True if some other code called allocate_memory for this
             # register

--- a/dwave/gate/qcdl/registers.py
+++ b/dwave/gate/qcdl/registers.py
@@ -244,6 +244,13 @@ class RegisterInitializerMixin:
         if isinstance(initial_value, np.ndarray):
             initial_value = initial_value.tolist()
 
+        # None means the caller gave no initial value. That distinction matters
+        # because a value that would never reach the qubit has to be reported
+        # rather than silently dropped.
+        initial_value_specified = initial_value is not None
+        if not initial_value_specified:
+            initial_value = 0.0 if str(dtype) == "float" else 0
+
         if length is None:
             length = len(initial_value) if isinstance(initial_value, Sequence) else 1
 
@@ -257,6 +264,14 @@ class RegisterInitializerMixin:
             name, initial_value=initial_value, length=length, dtype=dtype, signed=signed
         )
 
+        if alias is True and initial_value_specified:
+            raise QCDLUserError(
+                f"register {name!r} is an alias, so no memory is allocated for"
+                f" it and the initial value given here would never reach the"
+                f" qubit; drop the initial value, or drop alias=True to"
+                f" allocate new memory"
+            )
+
         # An alias deliberately names memory that already exists, and
         # ignore_reallocation is the documented opt out.
         modules[0].procedure.register_memory_allocation(
@@ -264,6 +279,7 @@ class RegisterInitializerMixin:
             name,
             dtype,
             allow_existing=alias is True or ignore_reallocation,
+            initial_value_specified=initial_value_specified,
         )
 
         if alias is not True:
@@ -664,16 +680,22 @@ class Register(IntegerOpsMixin, AssignmentOpsMixin, RegisterInitializerMixin, Ta
             one or more qubits. Typically, you create a register from a
             :class:`~dwave.gate.qcdl.Scope` object, which handles this parameter
             for you.
-        initial_value: Initial value. Defaults to 0.
+        initial_value: Initial value. Defaults to 0. Omit it when reusing a name
+            that is already allocated (see ``alias`` and
+            ``ignore_reallocation``): only the first allocation of a name takes
+            effect, so a value given for a later one is rejected rather than
+            silently discarded.
         name: Name for this register; useful for troubleshooting. If None, a
             name is generated. See the ``alias`` parameter for type punning.
         master_kwargs: Propagate this to the master instruction.  This parameter
             is intended for use by developers of QCDL.
         alias: Set to True if you are aliasing an existing register, and for
             type punning reuse that register's name in the ``name`` parameter.
-            Aliased registers are not reinitialized.
+            Aliased registers are not reinitialized, so you may not give an
+            ``initial_value``.
         ignore_reallocation: If True, the compiler does not reallocate if
-            already allocated (and does not raise an exception).
+            already allocated (and does not raise an exception). You may not
+            give an ``initial_value`` as well.
         scope_id: Identity of the :class:`~dwave.gate.qcdl.Scope` this register
             is derived from. The
             :meth:`~dwave.gate.qcdl.QCDLModuleContainer.Register` method sets
@@ -736,7 +758,7 @@ class Register(IntegerOpsMixin, AssignmentOpsMixin, RegisterInitializerMixin, Ta
     def __init__(
         self,
         modules: Sequence[QCDLModule],
-        initial_value: int = 0,
+        initial_value: int | None = None,
         name: str | None = None,
         master_kwargs: dict[str, Any] | None = None,
         alias: bool | str = False,
@@ -781,16 +803,22 @@ class FixedPointRegister(
             one or more qubits. Typically, you create a register from a
             :class:`~dwave.gate.qcdl.Scope` object, which handles this parameter
             for you.
-        initial_value: Initial value. Defaults to 0.0.
+        initial_value: Initial value. Defaults to 0.0. Omit it when reusing a
+            name that is already allocated (see ``alias`` and
+            ``ignore_reallocation``): only the first allocation of a name takes
+            effect, so a value given for a later one is rejected rather than
+            silently discarded.
         name: Name for this register; useful for troubleshooting. If None, a
             name is generated. See the ``alias`` parameter for type punning.
         master_kwargs: Propagate this to the master instruction. This parameter
             is intended for use by developers of QCDL.
         alias: Set to True if you are aliasing an existing register, and for
             type punning reuse that register's name in the ``name`` parameter.
-            Aliased registers are not reinitialized.
+            Aliased registers are not reinitialized, so you may not give an
+            ``initial_value``.
         ignore_reallocation: If True, the compiler does not reallocate if
-            already allocated (and does not raise an exception).
+            already allocated (and does not raise an exception). You may not
+            give an ``initial_value`` as well.
         scope_id: Identity of the :class:`~dwave.gate.qcdl.Scope` this register
             is derived from. The
             :meth:`~dwave.gate.qcdl.QCDLModuleContainer.FixedPointRegister`
@@ -834,7 +862,7 @@ class FixedPointRegister(
     def __init__(
         self,
         modules: Sequence[QCDLModule],
-        initial_value: float = 0.0,
+        initial_value: float | None = None,
         name: str | None = None,
         master_kwargs: dict[str, Any] | None = None,
         alias: bool | str = False,

--- a/dwave/gate/results.py
+++ b/dwave/gate/results.py
@@ -44,8 +44,12 @@ DEFAULT_TAG = ""
 def get_default_register(qubits: Iterable[str]) -> RegisterType:
     """The register used if none is provided.
 
-    This register will include all qubits in the circuit, regardless of which
-    have measurements. This is usually not what is desired.
+    This register includes all qubits in the circuit, regardless of which have
+    measurements, so unmeasured qubits are padded into the bitstring. This is
+    usually not what is desired, which is why
+    :meth:`.Result.get_memory` and :meth:`.Result.get_counts` default to
+    :meth:`.Result.get_measurements_register` instead and fall back to this
+    only when no qubit has measurements.
 
     Sorts qubits to have the highest index first, e.g., ``[q2, q1, q0]``
 
@@ -483,7 +487,11 @@ class Result(BaseModel):
             tag: Which data set to load. Defaults to
                 :attr:`dwave.gate.results.Result.default_tag`.
             register: List of qubit names to include in the register; determines
-                the inner dimension of the returned value.
+                the inner dimension of the returned value. Defaults to
+                :meth:`.get_measurements_register`, so qubits that were not
+                measured are left out rather than padded with
+                ``unmeasured_value``. Pass
+                :func:`.get_default_register` to include them.
             unmeasured_value: What to put in the register if a requested qubit
                 wasn't measured.
             shots: Overrides the shots in the result object.
@@ -495,6 +503,11 @@ class Result(BaseModel):
             tag = self.default_tag
         if self.measurements is None:
             raise RuntimeError("measurements are not available for this result")
+        if register is None:
+            # A qubit with no measurements has no bit to contribute, and padding
+            # one in makes the bitstring look like an outcome. Fall back to every
+            # qubit only when nothing was measured at all.
+            register = cast(RegisterType, self.get_measurements_register(tag)) or None
         return format_memory(
             self.measurements[tag],
             register=register,
@@ -517,7 +530,8 @@ class Result(BaseModel):
         Args:
             tag: Which data set to load. Defaults to
                 :attr:`dwave.gate.results.Result.default_tag`.
-            register: Forwarded to get_memory.
+            register: Forwarded to :meth:`.get_memory`, which defaults to
+                :meth:`.get_measurements_register`.
             post_select: If the counts dict should include splats or not.
             unmeasured_value: What to put in the register if a requested qubit
                 wasn't measured.

--- a/dwave/gate/results.py
+++ b/dwave/gate/results.py
@@ -652,16 +652,53 @@ class YieldHandling(enum.StrEnum):
         else:
             return YieldHandling[name]
 
+    @staticmethod
+    def _is_erasure(key: Any) -> bool:
+        """Whether a counts key records an erasure.
+
+        Only the string key formats can hold a splat: the
+        :func:`.count_measurements` function produces integer keys only for
+        memory that is entirely 0s and 1s.
+        """
+        return isinstance(key, str) and "*" in key
+
     def apply(
         self, distribution: dict[Any, int]
     ) -> tuple[dict[Any, float | int], float]:
+        """Apply this yield handling to a counts dict.
+
+        Args:
+            distribution: Counts, as returned by the
+                :func:`.count_measurements` function or the
+                :meth:`.Result.get_counts` method. Keys may be in any of the
+                formats that function produces.
+
+        Raises:
+            :exception:`ValueError`: If the distribution is empty, or if the
+                yield is too low for
+                :attr:`.renormalize_distribution_or_raise`.
+            :exception:`ZeroDivisionError`: If nothing survives post selection
+                and the distribution has to be renormalized.
+
+        Returns:
+            The handled distribution and the observed yield.
+        """
+        if not distribution:
+            raise ValueError("can not apply yield handling to an empty distribution")
+
         num_executed_shots: int = sum(distribution.values())
-        post_selected = {k: v for k, v in distribution.items() if "*" not in k}
+        post_selected = {
+            k: v for k, v in distribution.items() if not self._is_erasure(k)
+        }
         if not post_selected:
             # Put one key in the dict at least. Use a previously existing key as
             # a template so that the formatting is correct.
-            template_key: str = next(iter(distribution))
-            zeros_key = template_key.replace("1", "0").replace("*", "0")
+            template_key: Any = next(iter(distribution))
+            zeros_key = (
+                template_key.replace("1", "0").replace("*", "0")
+                if isinstance(template_key, str)
+                else 0
+            )
             post_selected[zeros_key] = 0
 
         num_post_selected_shots: int = sum(post_selected.values())

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -33,7 +33,7 @@ from dwave.gate.qcdl.qcdl_models import QCDLStatement
 available_operations = [
     name
     for name, obj in inspect.getmembers(operations, inspect.isfunction)
-    if obj.__module__ == operations.__name__ and not name.startswith("__")
+    if obj.__module__ == operations.__name__ and not name.startswith("_")
 ]
 
 
@@ -114,6 +114,152 @@ def test_operations(op_name):
     )
     if num_registers:
         assert "register" in statement.kwargs
+
+
+def _count_annotated(op_name, annotation):
+    parameters = inspect.signature(getattr(operations, op_name)).parameters.values()
+    return sum(1 for parameter in parameters if parameter.annotation == annotation)
+
+
+two_qubit_operations = [
+    name
+    for name in available_operations
+    if _count_annotated(name, QCDLModule) == 2
+]
+
+
+def test_module_only_exports_operations():
+    """``import *`` should bring in operations, not our imports."""
+    namespace = {}
+    exec("from dwave.gate.qcdl.operations import *", namespace)
+    exported = set(namespace) - {"__builtins__"}
+
+    assert exported == set(operations.__all__)
+    assert set(available_operations) <= exported
+    for leaked in ("np", "implementations", "inspect", "functools", "Sequence"):
+        assert leaked not in exported
+
+
+def test_all_lists_every_operation():
+    assert sorted(operations.__all__) == sorted(available_operations + ["AngleType"])
+
+
+def test_reset_is_an_importable_operation():
+    """``q0.reset()`` works only through __getattr__, so it has no signature."""
+    assert callable(operations.reset)
+    assert operations.reset.__doc__
+    assert list(inspect.signature(operations.reset).parameters) == ["qubit"]
+
+
+def test_reset_matches_the_statement_getattr_produces():
+    """The operation must be an alias for what the guide teaches, not a variant."""
+
+    @qcdl(1)
+    def with_operation(q0):
+        operations.x(q0)
+        operations.reset(q0)
+        operations.measure(q0)
+
+    @qcdl(1)
+    def with_getattr(q0):
+        operations.x(q0)
+        q0.reset()
+        operations.measure(q0)
+
+    assert with_operation().model_dump() == with_getattr().model_dump()
+
+
+@pytest.mark.parametrize("op_name", available_operations)
+def test_operations_reject_a_non_qubit(op_name):
+    """Without this the failure is an AttributeError naming ``procedure``."""
+    f = getattr(operations, op_name)
+    num_qubits = _count_annotated(op_name, QCDLModule)
+    num_angles = _count_annotated(op_name, AngleType)
+    needs_register = op_name in ("measure", "mced")
+
+    @qcdl(2)
+    def main(q0, q1):
+        args = [5] + [q1] * (num_qubits - 1) + [0.1] * num_angles
+        kwargs = dict(register=q0.Register(name="reg")) if needs_register else {}
+        f(*args, **kwargs)
+
+    with pytest.raises(QCDLUserError, match="must be a qubit"):
+        main()
+
+
+@pytest.mark.parametrize("value", [5, "q0", None, 3.14, [1]])
+def test_non_qubit_error_names_the_parameter_and_the_type(value):
+    @qcdl(1)
+    def main(q0):
+        operations.h(value)
+
+    with pytest.raises(QCDLUserError) as cm:
+        main()
+    message = str(cm.value)
+    assert "h() parameter 'qubit'" in message
+    assert type(value).__name__ in message
+
+
+@pytest.mark.parametrize("op_name", two_qubit_operations)
+def test_two_qubit_operations_need_distinct_qubits(op_name):
+    """``cx(q0, q0)`` used to build cleanly and fail only at the service."""
+    f = getattr(operations, op_name)
+    num_angles = _count_annotated(op_name, AngleType)
+
+    @qcdl(2)
+    def main(q0, q1):
+        f(q0, q0, *[0.1] * num_angles)
+
+    with pytest.raises(QCDLUserError, match="needs distinct qubits"):
+        main()
+
+
+@pytest.mark.parametrize("op_name", two_qubit_operations)
+def test_two_qubit_operations_accept_distinct_qubits(op_name):
+    f = getattr(operations, op_name)
+    num_angles = _count_annotated(op_name, AngleType)
+
+    @qcdl(2)
+    def main(q0, q1):
+        f(q0, q1, *[0.1] * num_angles)
+
+    assert main().program.statements[0].op in (op_name, "ry")
+
+
+def test_repeated_qubit_is_allowed_where_it_is_harmless():
+    """``barrier``/``initialize`` take a set of qubits, so repeats are benign."""
+
+    @qcdl(2)
+    def main(q0, q1):
+        operations.initialize(q0, q1, q0)
+        operations.barrier(q0, q0)
+        operations.measure(q0)
+
+    assert [s.op for s in main().program.statements] == [
+        "initialize",
+        "barrier",
+        "measure",
+    ]
+
+
+def test_validation_does_not_change_the_arity_error():
+    """A wrong number of arguments still reports against the real signature."""
+
+    @qcdl(1)
+    def main(q0):
+        operations.cx(q0)
+
+    with pytest.raises(TypeError, match="target_qubit"):
+        main()
+
+
+def test_operations_keep_their_metadata():
+    """The validation wrapper must not hide the signature or docs from sphinx."""
+    for name in available_operations:
+        f = getattr(operations, name)
+        assert f.__name__ == name
+        assert f.__doc__, name
+        assert f.__module__ == operations.__name__
 
 
 @pytest.mark.parametrize("mirror", [True, False])

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -121,10 +121,23 @@ def _count_annotated(op_name, annotation):
     return sum(1 for parameter in parameters if parameter.annotation == annotation)
 
 
+def _qubit_parameters(op_name):
+    parameters = inspect.signature(getattr(operations, op_name)).parameters.values()
+    return [p for p in parameters if p.annotation == QCDLModule]
+
+
+# Operations whose qubits are separate roles, so they have to be distinct.
 two_qubit_operations = [
     name
     for name in available_operations
-    if _count_annotated(name, QCDLModule) == 2
+    if len([p for p in _qubit_parameters(name) if p.kind is not p.VAR_POSITIONAL]) == 2
+]
+
+# Operations taking a set of qubits, where naming one twice is harmless.
+variadic_qubit_operations = [
+    name
+    for name in available_operations
+    if any(p.kind is p.VAR_POSITIONAL for p in _qubit_parameters(name))
 ]
 
 
@@ -226,20 +239,33 @@ def test_two_qubit_operations_accept_distinct_qubits(op_name):
     assert main().program.statements[0].op in (op_name, "ry")
 
 
-def test_repeated_qubit_is_allowed_where_it_is_harmless():
-    """``barrier``/``initialize`` take a set of qubits, so repeats are benign."""
+@pytest.mark.parametrize("op_name", variadic_qubit_operations)
+def test_repeated_qubit_is_allowed_where_it_is_harmless(op_name):
+    """A ``*qubits`` parameter is a set, so naming one twice is benign.
+
+    This is the other half of the rule ``_validate_qubit_args`` derives from the
+    signature: only *named* qubit parameters are separate roles.
+    """
+    f = getattr(operations, op_name)
 
     @qcdl(2)
     def main(q0, q1):
-        operations.initialize(q0, q1, q0)
-        operations.barrier(q0, q0)
-        operations.measure(q0)
+        f(q0, q1, q0)
 
-    assert [s.op for s in main().program.statements] == [
-        "initialize",
-        "barrier",
-        "measure",
-    ]
+    assert [s.op for s in main().program.statements] == [op_name]
+
+
+def test_variadic_and_two_qubit_operations_are_disjoint_and_complete():
+    """Every multi-qubit operation falls under exactly one half of the rule."""
+    assert set(two_qubit_operations).isdisjoint(variadic_qubit_operations)
+    assert set(variadic_qubit_operations) == {"barrier", "initialize"}
+    assert "cx" in two_qubit_operations and "swap" in two_qubit_operations
+
+
+def test_every_operation_validates_its_arguments():
+    """A new operation must not be able to skip the check by omitting a kwarg."""
+    for name in available_operations:
+        assert hasattr(getattr(operations, name), "__wrapped__"), name
 
 
 def test_validation_does_not_change_the_arity_error():

--- a/tests/test_qcdl_circuit.py
+++ b/tests/test_qcdl_circuit.py
@@ -668,6 +668,140 @@ class TestQCDLDecoratorModes:
         assert main_env(my_kwarg=rand_num) == obj.sequence(my_kwarg=rand_num)
 
 
+class TestQCDLNumQubitsValidation:
+    """num_qubits has to be able to produce qubits."""
+
+    @pytest.mark.parametrize("num_qubits", [0, -1, -10])
+    def test_num_qubits_below_one_raises(self, num_qubits):
+        with pytest.raises(QCDLUserError, match="must be at least 1"):
+            qcdl(num_qubits)
+
+    @pytest.mark.parametrize("num_qubits", [2.0, 2.5, "2", True, [2]])
+    def test_num_qubits_must_be_an_integer(self, num_qubits):
+        with pytest.raises(QCDLUserError, match="must be an integer"):
+            qcdl(num_qubits)
+
+    def test_decorator_used_without_calling_it_raises(self):
+        """A bare @qcdl passes the function in as num_qubits."""
+
+        def main(q0):
+            pass
+
+        with pytest.raises(QCDLUserError, match="must be called"):
+            qcdl(main)
+
+    def test_num_qubits_of_one_is_allowed(self):
+        @qcdl(1)
+        def main(q0):
+            q0.measure()
+
+        assert [str(q) for q in main().program.signature.qubits_used] == ["q0"]
+
+
+class TestQCDLSignatureValidation:
+    """The signature of the decorated function has to match the qubits made.
+
+    Qubits are injected by keyword, so a signature that does not name them all
+    either loses a qubit or leaves a parameter unbound. Both were silent.
+    """
+
+    def test_generated_qubit_with_no_parameter_raises(self):
+        @qcdl(3)
+        def main(q0, q1):
+            q0.h()
+
+        with pytest.raises(QCDLUserError, match="no parameter for q2"):
+            main()
+
+    def test_every_generated_qubit_named_is_accepted(self):
+        @qcdl(3)
+        def main(q0, q1, q2, my_angle=0):
+            q0.h()
+
+        assert [str(q) for q in main(my_angle=0.5).program.signature.qubits_used] == [
+            "q0"
+        ]
+
+    def test_var_keyword_signature_absorbs_every_qubit(self):
+        @qcdl(3)
+        def main(**kwargs):
+            assert set(kwargs) == {"q0", "q1", "q2"}
+            kwargs["q0"].h()
+
+        main()
+
+    def test_environment_may_supply_more_qubits_than_the_signature(self):
+        """The environment supplies its whole set, so dropping is expected."""
+        env = FakeEnv(["q0", "q1", "q2"])
+
+        @qcdl(environment=env)
+        def main(q0):
+            q0.measure()
+
+        assert isinstance(main(), QCDLProgram)
+
+    def test_parameter_not_named_qN_explains_the_rule(self):
+        @qcdl(1)
+        def main(alpha):
+            pass
+
+        with pytest.raises(TypeError) as excinfo:
+            main()
+
+        message = str(excinfo.value)
+        # keep python's own wording, then say why nothing was passed
+        assert "missing 1 required positional argument: 'alpha'" in message
+        assert "q0, q1, ..." in message
+        assert "'alpha' does not match" in message
+
+    def test_qubit_parameter_beyond_num_qubits_explains_the_rule(self):
+        @qcdl(2)
+        def main(q0, q1, q2):
+            pass
+
+        with pytest.raises(TypeError) as excinfo:
+            main()
+
+        message = str(excinfo.value)
+        assert "missing 1 required positional argument: 'q2'" in message
+        assert "supplied q0, q1" in message
+        assert "num_qubits" in message
+
+    def test_several_unfilled_parameters_are_reported_together(self):
+        @qcdl(1)
+        def main(q0, alpha, beta):
+            pass
+
+        with pytest.raises(
+            TypeError, match="missing 2 required positional arguments: 'alpha', 'beta'"
+        ):
+            main()
+
+    def test_unfilled_parameter_may_be_passed_by_the_caller(self):
+        @qcdl(1)
+        def main(q0, alpha):
+            q0.comment(str(alpha))
+            q0.measure()
+
+        assert isinstance(main(alpha=3), QCDLProgram)
+
+    def test_keyword_only_parameter_without_a_default_is_reported(self):
+        @qcdl(1)
+        def main(q0, *, alpha):
+            pass
+
+        with pytest.raises(TypeError, match="missing 1 required positional argument"):
+            main()
+
+    def test_inferred_mode_never_drops_or_starves_a_parameter(self):
+        @qcdl()
+        def main(q0, q5, alpha=1):
+            q0.measure()
+            q5.measure()
+
+        assert [str(q) for q in main().program.signature.qubits_used] == ["q0", "q5"]
+
+
 def test_fspec():
     def my_meth1(q0, q1, q2=321):
         pass

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -588,16 +588,102 @@ def test_duplicate_register_name_reports_the_dtype_it_has():
 
 
 def test_duplicate_register_name_allowed_by_ignore_reallocation():
+    """Opting in gets you a handle on the register that is already there."""
+
     @qcdl(1)
     def main(q0):
         q0.Register(1, name="dup")
-        q0.Register(2, name="dup", ignore_reallocation=True)
+        q0.Register(name="dup", ignore_reallocation=True)
         q0.measure()
 
     allocations = [
         s for s in main().program.statements if s.op == "allocate_memory"
     ]
-    assert [a.kwargs["initial_value"] for a in allocations] == [1, 2]
+    assert len(allocations) == 2
+    assert allocations[0].kwargs["initial_value"] == 1
+    assert allocations[1].kwargs["ignore_reallocation"] is True
+
+
+def test_ignore_reallocation_still_rejects_an_initial_value():
+    """The second value is explicit information the compiler would discard."""
+
+    @qcdl(1)
+    def main(q0):
+        q0.Register(1, name="dup")
+        q0.Register(2, name="dup", ignore_reallocation=True)
+
+    with pytest.raises(QCDLUserError) as cm:
+        main()
+    message = str(cm.value)
+    assert "would never reach the qubit" in message
+    assert "drop the initial value" in message
+
+
+def test_an_explicit_zero_counts_as_an_initial_value():
+    """0 is the default, but passing it is still saying something."""
+
+    @qcdl(1)
+    def main(q0):
+        q0.Register(name="dup")
+        q0.Register(0, name="dup", ignore_reallocation=True)
+
+    with pytest.raises(QCDLUserError, match="would never reach the qubit"):
+        main()
+
+
+def test_ignore_reallocation_on_a_fresh_name_may_carry_a_value():
+    """Nothing is discarded when the name is not already allocated."""
+
+    @qcdl(1)
+    def main(q0):
+        q0.Register(7, name="fresh", ignore_reallocation=True)
+
+    allocations = [
+        s for s in main().program.statements if s.op == "allocate_memory"
+    ]
+    assert [a.kwargs["initial_value"] for a in allocations] == [7]
+
+
+def test_alias_rejects_an_initial_value():
+    """An alias is never initialized, so its value is dead on arrival."""
+
+    @qcdl(1)
+    def main(q0):
+        q0.FixedPointRegister(1.0, name="fr")
+        q0.Register(3, name="fr", alias=True)
+
+    with pytest.raises(QCDLUserError, match="is an alias"):
+        main()
+
+
+def test_duplicate_array_name_with_ignore_reallocation_still_raises():
+    """An Array always carries contents, so it can never opt in."""
+
+    @qcdl(1)
+    def main(q0):
+        Array(q0, [1, 2], name="arr")
+        Array(q0, [3, 4], name="arr", ignore_reallocation=True)
+
+    with pytest.raises(QCDLUserError, match="would never reach the qubit"):
+        main()
+
+
+@pytest.mark.parametrize(
+    "register_type,expected", [("Register", 0), ("FixedPointRegister", 0.0)]
+)
+def test_omitted_initial_value_still_allocates_zero(register_type, expected):
+    """The sentinel default has to resolve per dtype, not leak out as None."""
+
+    @qcdl(1)
+    def main(q0):
+        getattr(q0, register_type)(name="r")
+
+    allocation = next(
+        s for s in main().program.statements if s.op == "allocate_memory"
+    )
+    value = allocation.kwargs["initial_value"]
+    assert value == expected
+    assert isinstance(value, type(expected))
 
 
 def test_aliasing_an_allocated_register_is_not_a_duplicate():

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -25,6 +25,7 @@ from dwave.gate.qcdl import (
     QCDLModule,
     QCDLUserError,
     Register,
+    Scope,
     arbitrary_function,
     procedure,
     qcdl,
@@ -559,6 +560,124 @@ def test_find_modules():
         assert set(
             [q.qcdl_module_name for q in QCDLModule.find_modules(reg, q1)]
         ) == set(["q0", "q1"])
+
+    assert main()
+
+
+def test_duplicate_register_name_raises():
+    """The compiler keeps the first allocation, so the second value is lost."""
+
+    @qcdl(1)
+    def main(q0):
+        q0.Register(1, name="dup")
+        q0.Register(2, name="dup")
+
+    with pytest.raises(QCDLUserError) as cm:
+        main()
+    assert "'dup' is already allocated on q0" in str(cm.value)
+
+
+def test_duplicate_register_name_reports_the_dtype_it_has():
+    @qcdl(1)
+    def main(q0):
+        q0.Register(name="clash")
+        q0.FixedPointRegister(name="clash")
+
+    with pytest.raises(QCDLUserError, match="with dtype int"):
+        main()
+
+
+def test_duplicate_register_name_allowed_by_ignore_reallocation():
+    @qcdl(1)
+    def main(q0):
+        q0.Register(1, name="dup")
+        q0.Register(2, name="dup", ignore_reallocation=True)
+        q0.measure()
+
+    allocations = [
+        s for s in main().program.statements if s.op == "allocate_memory"
+    ]
+    assert [a.kwargs["initial_value"] for a in allocations] == [1, 2]
+
+
+def test_aliasing_an_allocated_register_is_not_a_duplicate():
+    """alias=True deliberately names memory that already exists."""
+
+    @qcdl(1)
+    def main(q0):
+        q0.FixedPointRegister(initial_value=1, name="fr")
+        integer_view = q0.Register(name="fr", alias=True)
+        integer_view += integer_view & 4
+
+    allocations = [
+        s for s in main().program.statements if s.op == "allocate_memory"
+    ]
+    assert len(allocations) == 1
+
+
+def test_alias_of_another_register_is_still_tracked():
+    """A string alias allocates a new name, so redeclaring it is a duplicate."""
+
+    @qcdl(1)
+    def main(q0):
+        q0.Register(name="original")
+        q0.Register(name="punned", alias="original")
+        q0.Register(name="punned")
+
+    with pytest.raises(QCDLUserError, match="'punned' is already allocated"):
+        main()
+
+
+def test_a_scope_register_may_be_narrowed_with_an_alias():
+    """The documented way to write to one qubit's copy of a shared register."""
+
+    @qcdl(2)
+    def main(q0, q1):
+        scope = Scope(q0, q1)
+        scope.Register(name="bit")
+        q0.measure(register=q0.Register(name="bit", alias=True))
+
+    allocations = [
+        s for s in main().program.statements if s.op == "allocate_memory"
+    ]
+    assert len(allocations) == 1
+    assert [str(q) for q in allocations[0].modules] == ["q0", "q1"]
+
+
+def test_same_register_name_on_different_qubits_is_fine():
+    @qcdl(2)
+    def main(q0, q1):
+        q0.Register(1, name="r0")
+        q1.Register(2, name="r0")
+
+    allocations = [
+        s for s in main().program.statements if s.op == "allocate_memory"
+    ]
+    assert [a.kwargs["initial_value"] for a in allocations] == [1, 2]
+
+
+def test_duplicate_array_name_raises():
+    @qcdl(1)
+    def main(q0):
+        Array(q0, [1, 2], name="arr")
+        Array(q0, [3, 4], name="arr")
+
+    with pytest.raises(QCDLUserError, match="'arr' is already allocated"):
+        main()
+
+
+def test_register_names_are_tracked_per_procedure():
+    """A procedure has its own statements, so it may reuse a name."""
+
+    @procedure
+    def inner(qa):
+        qa.Register(name="local")
+        qa.rx(0.123)
+
+    @qcdl(1)
+    def main(q0):
+        q0.Register(name="local")
+        inner(q0)
 
     assert main()
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -517,3 +517,47 @@ def test_yield_handling():
 
     with pytest.raises(ValueError):
         YieldHandling.renormalize_distribution_or_raise.apply(yield_5pct)
+
+
+@pytest.mark.parametrize("key_format", ["bin", "hex", None, "{0:>03b}"])
+def test_yield_handling_accepts_every_count_key_format(key_format):
+    """count_measurements and YieldHandling have to compose.
+
+    ``key_format=None`` produces integer keys, which cannot hold a splat but
+    used to raise ``TypeError`` on the ``"*" not in key`` test.
+    """
+    distribution = count_measurements([[0, 1, 1]] * 4, key_format=key_format)
+
+    handled, observed_yield = YieldHandling.only_post_selected_counts.apply(
+        distribution
+    )
+    assert handled == distribution
+    assert observed_yield == 1.0
+
+
+def test_yield_handling_with_integer_keys_renormalizes():
+    distribution = count_measurements([[0, 1]] * 4, key_format=None)
+
+    assert YieldHandling.renormalize_distribution.apply(distribution) == (
+        {1: 4.0},
+        1.0,
+    )
+
+
+def test_yield_handling_zeros_key_for_non_string_keys():
+    """The all-erasures fallback needs a key of the caller's own format."""
+    handled, observed_yield = YieldHandling.only_post_selected_counts.apply({"0*": 10})
+    assert handled == {"00": 0}
+    assert observed_yield == 0
+
+    # an integer-keyed distribution can not contain erasures, so the fallback is
+    # only reachable by handing apply() a key it did not produce
+    handled, observed_yield = YieldHandling.ignore_splats.apply({7: 10})
+    assert handled == {7: 10}
+    assert observed_yield == 1.0
+
+
+def test_yield_handling_rejects_an_empty_distribution():
+    """post_select can empty a counts dict; StopIteration is not a useful error."""
+    with pytest.raises(ValueError, match="empty distribution"):
+        YieldHandling.only_post_selected_counts.apply({})

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -415,6 +415,59 @@ def test_none_in_register(nones, shots=10):
     counts = count_measurements(memory)
     assert counts == {expected: shots}
 
+# ---------------------------------------------------------------------------
+# The register Result uses when none is given
+# ---------------------------------------------------------------------------
+
+
+def _result_with(measurements, shots=10) -> Result:
+    return Result.model_validate(
+        {"num_shots": shots, "measurements": {"": measurements}}
+    )
+
+
+def test_get_counts_uses_the_measured_register():
+    """An unmeasured qubit has no bit, so it must not be padded into the key."""
+    result = _result_with([[], [1] * 3, [0] * 3], shots=3)
+
+    assert result.get_measurements_register() == ["q2", "q1"]
+    assert result.get_counts() == [{"01": 3}]
+
+
+def test_get_memory_uses_the_measured_register():
+    result = _result_with([[], [1] * 3, [0] * 3], shots=3)
+
+    assert result.get_memory().shape == (1, 3, 2)
+
+
+def test_default_register_is_still_reachable():
+    """Padding is available for callers that want every qubit."""
+    result = _result_with([[], [1] * 3, [0] * 3], shots=3)
+    register = get_default_register(["q0", "q1", "q2"])
+
+    assert result.get_counts(register=register) == [{"01_": 3}]
+
+
+def test_an_explicit_register_still_wins():
+    result = _result_with([[1] * 3, [0] * 3], shots=3)
+
+    assert result.get_counts(register=["q0"]) == [{"1": 3}]
+
+
+def test_get_counts_when_every_qubit_was_measured():
+    result = _result_with([[0, 1, 0, 1], [0, 1, 0, 1]], shots=4)
+
+    assert result.get_counts() == [{"00": 2, "11": 2}]
+    assert result.get_memory().shape == (1, 4, 2)
+
+
+def test_get_counts_when_nothing_was_measured():
+    result = _result_with([[], []], shots=3)
+
+    assert result.get_measurements_register() == []
+    assert result.get_counts() == []
+
+
 def test_encode_decode_measurements():
     size = 1000
     arr = np.random.randint(-1, 1, size=size)

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -347,6 +347,84 @@ def test_one_to_all():
             assert s.args[0] == reg_name
 
 
+def _one_to_all_statement(destinations_from):
+    """Build a one_to_all and return its statement.
+
+    ``destinations_from`` turns the listener Scope into whatever form of
+    destination the test wants to pass.
+    """
+
+    @qcdl(3)
+    def main(q0, q1, q2):
+        send_register = q0.Register(name="reg123")
+        sc = Scope(q1, q2)
+        q0.one_to_all(destinations_from(sc, q1), send_register == 1)
+
+    statements = [
+        QCDLStatement.model_validate(stmt)
+        for stmt in main().model_dump(exclude_unset=True)["program"]["statements"]
+    ]
+    return next(s for s in statements if s.op == "one_to_all")
+
+
+@pytest.mark.parametrize(
+    "destinations_from,expected",
+    [
+        (lambda sc, q1: sc, ["q1", "q2"]),
+        (lambda sc, q1: sc.qcdl_modules, ["q1", "q2"]),
+        (lambda sc, q1: tuple(sc.qcdl_modules), ["q1", "q2"]),
+        (lambda sc, q1: list(reversed(sc.qcdl_modules)), ["q2", "q1"]),
+        (lambda sc, q1: q1, ["q1"]),
+        (lambda sc, q1: [q1, sc], ["q1", "q2"]),
+        (lambda sc, q1: [q1, q1], ["q1"]),
+    ],
+    ids=["scope", "list", "tuple", "reversed", "module", "mixed", "repeated"],
+)
+def test_one_to_all_destination_forms(destinations_from, expected):
+    """The guide passes ``scope.qcdl_modules``, which used to raise."""
+    assert _one_to_all_statement(destinations_from).kwargs["qubits"] == expected
+
+
+def test_one_to_all_scope_id_comes_from_a_scope_only():
+    """A bare sequence has no identity, so it contributes no scope_id."""
+    from_scope = _one_to_all_statement(lambda sc, q1: sc)
+    from_list = _one_to_all_statement(lambda sc, q1: sc.qcdl_modules)
+
+    assert from_scope.kwargs["scope_id"] is not None
+    assert from_list.kwargs["scope_id"] is None
+
+
+@pytest.mark.parametrize("destinations", [5, "q1", None, 3.14])
+def test_one_to_all_rejects_a_non_module(destinations):
+    @qcdl(2)
+    def main(q0, q1):
+        send_register = q0.Register(name="reg123")
+        q0.one_to_all(destinations, send_register == 1)
+
+    with pytest.raises(QCDLUserError, match="must be a Scope, a QCDLModule"):
+        main()
+
+
+def test_one_to_all_rejects_a_non_module_in_a_sequence():
+    @qcdl(2)
+    def main(q0, q1):
+        send_register = q0.Register(name="reg123")
+        q0.one_to_all([q1, 7], send_register == 1)
+
+    with pytest.raises(QCDLUserError, match="every item in destinations"):
+        main()
+
+
+def test_one_to_all_rejects_an_empty_sequence():
+    @qcdl(2)
+    def main(q0, q1):
+        send_register = q0.Register(name="reg123")
+        q0.one_to_all([], send_register == 1)
+
+    with pytest.raises(QCDLUserError, match="does not hold any qubits"):
+        main()
+
+
 def test_break_outside_loop():
     @qcdl(1)
     def main(q0):


### PR DESCRIPTION
## Summary

Client-side fixes for findings from the QCDL alpha test report (2026-08-18). Each
of these was reported as something `dwave-gate` accepts silently and the service
either rejects one round trip later or, worse, executes into a plausible-looking
wrong answer.

**Closes 11 findings:** QCDL-03, 04, 05, 06, 07, 10, 12, 13, 14, 25, 26.
**Partially addresses QCDL-23:** adds the missing `sxdg` gate.

Nothing here touches the service, the transpiler, or `dwave-cloud-client`, so the
report's two critical findings (QCDL-16 register-driven rotations, QCDL-09 mixed
register arithmetic) are still open. See [Follow-ups](#follow-ups).

## What changed

### `@qcdl` decorator validation — QCDL-03 / 04 / 05

`qcdl_circuit.py`

- `num_qubits` is validated when the decorator is built: `< 1`, non-integers, and
  a bare `@qcdl` (used without parentheses, so the function itself arrives as
  `num_qubits`) all raise `QCDLUserError`. Previously `@qcdl(0)` and `@qcdl(-1)`
  built an empty program.
- Qubits are injected *by keyword*, so a parameter that is not named `q<N>`
  silently receives nothing. Any required parameter left unbound now raises a
  `TypeError` that keeps Python's own `missing 1 required positional argument:
  'alpha'` wording and then explains the rule and what was actually supplied.
  This was the single most confusing failure in the report.
- If `num_qubits` generates a qubit the signature has no parameter for, that
  qubit was previously dropped from the program in silence. It now raises,
  naming the dropped qubit. Environment mode is exempt, since an environment
  legitimately supplies its whole set.

### Gate argument validation — QCDL-06 / 07

`operations.py`

A `_validate_qubit_args` decorator on all 34 operations checks the qubit
arguments before the statement is recorded:

- A non-qubit argument raises `QCDLUserError: h() parameter 'qubit' must be a
  qubit, not int (5); …` instead of surfacing later as
  `AttributeError: 'int' object has no attribute 'procedure'`.
- Two-qubit gates reject a repeated qubit: `cx() needs distinct qubits, but
  parameters 'control_qubit' and 'target_qubit' are both q0`. `cx(q0, q0)`
  previously built cleanly and failed only at submission.

Whether the qubits must be distinct is derived from the signature rather than
configured per gate: each *named* qubit parameter is a separate role in the
operation, whereas a `*qubits` parameter is a set, so `initialize(q0, q1, q0)`
and `barrier(q0, q0)` remain legal.

A wrong *number* of arguments still reports against the real signature, and
`functools.wraps` keeps signatures and docstrings intact for sphinx.

### Duplicate register declarations — QCDL-10

`components.py`, `registers.py`

The compiler keeps the *first* allocation of a register name, so re-declaring
one was a silent no-op that discarded the second initial value.
`Procedure.register_memory_allocation` now tracks names per module per procedure
and reports the collision. The same name on different qubits, and in a nested
procedure, is still fine.

Re-declaring deliberately is allowed via the existing `alias=True` /
`ignore_reallocation=True` arguments — but **not** together with an explicit
`initial_value`, because that value is information the caller stated explicitly
and the compiler would throw away:

| | already allocated | fresh name |
|---|---|---|
| plain redeclaration | raise | — |
| `ignore_reallocation=True`, no value | allowed | allowed |
| `ignore_reallocation=True`, explicit value | raise | allowed |
| `alias=True`, no value | allowed | allowed |
| `alias=True`, explicit value | raise | raise |

`alias=True` raises even for a fresh name: an alias never emits an allocation, so
its initial value is dead on arrival. String aliases (`alias="other"`) are left
alone — those do emit an allocation carrying the value, so it is the compiler's
call.

To tell an omitted initial value from an explicit `0`, `Register` and
`FixedPointRegister` now default `initial_value` to `None` and resolve it per
dtype (`0` / `0.0`). `Array` needed no change: its `initial_value` is a required
positional, so array contents always count as explicit.

### `one_to_all` argument types — QCDL-14

`components.py`

`QCDLModule.one_to_all(destinations, …)` accepted only a `Scope`, so passing
`scope.qcdl_modules` — as the guide does — failed with an internal-sounding
`AttributeError: 'list' object has no attribute 'qcdl_modules'`. It now accepts a
`Scope`, a single `QCDLModule`, or a sequence of either, deduplicated and in
order. `scope_id` is carried only by a real `Scope`, since a bare sequence has no
identity. Anything else gets a message naming what was expected.

### Result API — QCDL-12 / 13

`results.py`

- `get_counts()` and `get_memory()` now default their register to
  `get_measurements_register()`, so a qubit that was never measured is left out
  rather than padded into the bitstring as `_`. A three-qubit circuit measuring
  two qubits used to report `'1_'`; it now reports `'1'`. The old behaviour is
  still reachable by passing `register=get_default_register(...)` explicitly, and
  the all-qubits register remains the fallback when nothing was measured at all.
- `YieldHandling.apply()` no longer assumes string keys. Feeding it
  `count_measurements(key_format=None)` output raised
  `TypeError: argument of type 'numpy.int64' is not a container`; integer keys
  cannot hold an erasure, so they are now treated as splat-free. The
  all-erasures fallback had the same assumption one line down.
- `apply({})` raises `ValueError` instead of leaking `StopIteration`, which
  silently terminates any generator it is raised in. An empty counts dict is a
  natural output of `get_counts(post_select=True)`.

### Namespace and missing operations — QCDL-25 / 26 / 23

`operations.py`

- Added `__all__`, so `from dwave.gate.qcdl.operations import *` brings in the
  operations and `AngleType` only, rather than also binding `np`, `Any`,
  `Sequence`, `TypeAlias` and the `implementations` module. Dropped the unused
  `Sequence` import.
- Added `reset(qubit)`. It was taught in the guide as `q0.reset()`, which worked
  only through `__getattr__`, so it had no importable function, signature or
  docstring. The operation emits a byte-identical statement to `q0.reset()`,
  asserted by a test, so it is an alias for the documented behaviour rather than
  a variant.
- Added `sxdg(qubit)`, one of the three Qiskit-parity gaps in QCDL-23. It emits
  the op name directly, matching `sdg` / `tdg`, since `sxdg` is a real
  `QuantumCircuit` method and the transpiler is Qiskit-based.

### Documentation

`docs/workflow.rst`

- The reset examples now use the importable `reset` operation. One of them also
  imported `initialize` and never used it.
- `detect_erasure_example(q)` declared a parameter named `q`, which can never
  receive a qubit. Renamed to `q0`. It would have raised under the new QCDL-03
  check; it survived because the example is defined and never called.
- The `all_to_all` example (and the matching docstring in `components.py`)
  re-declared a register name to get a single-qubit view of shared memory. That
  is exactly what `alias=True` is for, so both now use it. Semantics are
  unchanged — the aliased register still writes to `q0` only, without mirroring.

## Behaviour changes reviewers should know about

Several things that previously succeeded now raise. All of them were reported as
defects, but they are visible:

1. `@qcdl(0)`, `@qcdl(-1)`, `@qcdl(2.5)`, bare `@qcdl` → `QCDLUserError`.
2. `@qcdl(N)` with a signature that does not name all N qubits → `QCDLUserError`.
3. A two-qubit gate given the same qubit twice → `QCDLUserError`.
4. A non-qubit passed to a gate → `QCDLUserError`, not `AttributeError`.
5. A duplicate register name → `QCDLUserError`.
6. `alias=True` or `ignore_reallocation=True` together with an `initial_value` →
   `QCDLUserError`.
7. `Register(None, name="r")` used to raise; `None` now means "use the default".
8. `get_counts()` / `get_memory()` bitstrings may be narrower than before, since
   unmeasured qubits are dropped.
9. `from dwave.gate.qcdl.operations import *` no longer binds `np`,
   `implementations`, or the typing helpers.

## Testing

`pytest` — **438 passing**, up from 300 on `main`. New coverage in
`test_qcdl_circuit.py`, `test_operations.py`, `test_registers.py`,
`test_scope.py` and `test_results.py` for every fix above, including the
happy paths each new check could plausibly break.

`make -C docs doctest` — 102 `testcode` blocks execute. Two pre-existing
failures in `implementations.py` docstrings (they use `Register` without
importing it) are untouched and pass only because an earlier block in the same
document imports it.

One thing that is **not** verified: `sxdg` is checked for the QCDL it emits, but
not against a live solver's operation whitelist. It needs one integration smoke
test. If the service rejects it, the fallback is emitting `rx(-π/2)` the way
`sy` / `sydg` emit `ry(±π/2)`, at the cost of a global phase.

The `qcdl_alpha_tests` suite is deliberately untouched. Six of its
`xfail(strict=True)` cases now XPASS — QCDL-03, 04, 06, 10, 12, 13 — which is the
report's own signal that a finding is fixed, and eleven tests that pinned the old
behaviour now fail on purpose. That repo and the report need a follow-up pass.

## Follow-ups

Not in this PR, roughly in the order I would do them:

- **QCDL-09** (critical, silent wrong result) — reject mixed
  `Register` / `FixedPointRegister` arithmetic. `OpsMixin._broadcasted_op` is the
  single chokepoint; it needs `RegisterExpression` to carry a dtype so the check
  propagates through nested expressions. That would also fix the related latent
  bug where a float-valued expression exposes `&`, `|`, `^` and `>>`.
- **QCDL-16** (critical, silent wrong result) — the root cause is a unit mismatch
  in the service transpiler, but `dwave-gate` can stop the silent failure by
  refusing register-valued angles on any gate the transpiler rewrites (only `rz`
  and `p` are verified correct). Needs a decision on raise vs. warn.
- **QCDL-11 / 22** — export `Result` and `YieldHandling` from `dwave.gate` (the
  guide already cross-references `dwave.gate.Result` in five places, all broken)
  and add a documented constructor for
  `Result.model_validate(orjson.loads(future.answer_data.read()))`.
- **QCDL-20** — the Simulator Configuration table is wrong on three of four rows
  and still carries a `.. todo::`.
- **QCDL-02** — an attribute typo puts a live `QCDLStatementBridge` in the
  payload, failing at encode time rather than at the statement.
- **QCDL-15 / 18 / 19 / 08 / 23** — documentation corrections in this repo.
- **QCDL-01** — validate instruction names with an explicit escape hatch. Needs
  the list of ops the compiler accepts, so it needs coordination.
- **QCDL-17 / 21** and the environment note are the transpiler and
  `dwave-cloud-client` respectively, not this repo.

Also noticed while working here, not from the report:

- `initialize()` and `barrier()` with no arguments raise
  `IndexError: tuple index out of range`.
- Most `@qcdl` examples in the guide define a circuit and never call it, so
  `make docs doctest` never executes the body. That is how the `q`-instead-of-`q0`
  parameter above survived; adding the call line to each example would catch the
  next one.
- `reno` is a dev dependency but there is no `releasenotes/` directory, so this
  PR adds no release note.
