### PR TITLE
Add `LeapQCDLSimulator`, an Ocean sampler-like interface for the QCDL solver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,21 +38,16 @@ that can be passed to a compiler or simulator:
 
     qcdl_program = main()
 
-To run the program on a solver, use the Ocean SDK's cloud client to locate a solver
-that supports QCDL and submit the dictionary via ``sample_qcdl``:
+To run the program on a solver, use the ``LeapQCDLSimulator`` to locate a solver
+that supports QCDL and submit the QCDL program via ``run``:
 
 .. code-block:: python
 
-    import orjson
-    from dwave.cloud import Client
-    from dwave.gate.results import Result
+    from dwave.gate.qcdl.leap import LeapQCDLSimulator
 
-    client = Client.from_config()
-    solver = client.get_solver(supported_problem_types__contains="qcdl")
-
-    response = solver.sample_qcdl(qcdl_program, shots=3)
-    answer = orjson.loads(response.answer_data.read())
-    result = Result(**answer)
+    simulator = LeapQCDLSimulator()
+    future = simulator.run(qcdl_program, shots=3)
+    result = future.result()
 
 Access measurements and sample counts by calling 
 ``result.measurements`` or ``result.get_counts()`` respectively.

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ that supports QCDL and submit the QCDL program via ``run``:
 
     simulator = LeapQCDLSimulator()
     future = simulator.run(qcdl_program, shots=3)
-    result = future.result()
+    result = future.result().result
 
 Access measurements and sample counts by calling 
 ``result.measurements`` or ``result.get_counts()`` respectively.

--- a/docs/qcdl.rst
+++ b/docs/qcdl.rst
@@ -17,6 +17,11 @@ Classes
     :show-inheritance:
     :inherited-members:
 
+.. autoclass:: LeapQCDLSimulator
+    :members:
+    :show-inheritance:
+    :inherited-members:
+
 Utilities
 =========
 

--- a/dwave/gate/qcdl/__init__.py
+++ b/dwave/gate/qcdl/__init__.py
@@ -16,6 +16,7 @@ from . import operations
 from .components import QCDLModule, QCDLModuleContainer, Scope, procedure
 from .constants import LogicalOutcomeToInteger
 from .exceptions import QCDLInternalError, QCDLUserError
+from .leap import LeapQCDLSimulator
 from .qcdl_circuit import qcdl
 from .qcdl_models import QCDLProgram, QCDLProcedureDef, QCDLStatement
 from .registers import FixedPointRegister, Register, arbitrary_function
@@ -24,6 +25,7 @@ from .transformer import display_qcdl, print_qcdl
 
 __all__ = [
     "FixedPointRegister",
+    "LeapQCDLSimulator",
     "LogicalOutcomeToInteger",
     "QCDLInternalError",
     "QCDLUserError",

--- a/dwave/gate/qcdl/leap.py
+++ b/dwave/gate/qcdl/leap.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import cached_property
-from typing import Any, Self
+from typing import Any, NamedTuple, Self
 
 import orjson
 from dwave.cloud.client import Client
@@ -58,7 +58,7 @@ class LeapQCDLSimulator:
 
             simulator = LeapQCDLSimulator()
             future = simulator.run(qcdl_program, shots=100)
-            result = future.result()
+            result = future.result().result
 
         Access measurements and sample counts by calling
         ``result.measurements`` or ``result.get_counts()`` respectively.
@@ -163,10 +163,18 @@ class LeapQCDLSimulator:
         # raise exceptions from the runtime context as they're not handled here
         return None
 
-    def run(self, qcdl: QCDLProgram | Mapping[str, Any], **params) -> Future[Result]:
+    class RunResult(NamedTuple):
+        """:meth:`~dwave.gate.qcdl.leap.LeapQCDLSimulator.run` method future result
+        """
+        result: Result
+        # note: use a string annotation to avoid dependency on dwave-system
+        info: 'dwave.system.samplers.ResultInfoDict'
+
+    def run(self, qcdl: QCDLProgram | Mapping[str, Any], **params) -> Future[RunResult]:
         """Run the :term:`QCDL` program using the selected Leap simulator,
-        and return the :class:`~dwave.gate.results.Result` in a
-        class:`~concurrent.futures.Future`.
+        and return the :class:`~dwave.gate.results.Result`, alongside the SAPI
+        job metadata, both wrapped in a :class:`~dwave.gate.qcdl.leap.LeapQCDLSimulator.RunResult`
+        and returned in a class:`~concurrent.futures.Future`.
 
         Args:
             qcdl:
@@ -181,9 +189,18 @@ class LeapQCDLSimulator:
         response = self.solver.sample_qcdl(qcdl, **params)
 
         def decode():
+            # decode/construct the QCDL result
             answer = orjson.loads(response.answer_data.read())
-            return Result(**answer)
+            result = Result(**answer)
 
-        result = self._executor.submit(decode)
+            # collect metadata of interest
+            info = dict(
+                timing=response.timing.copy(),
+                problem_id=response.id,
+                problem_label=response.label,
+                problem_data_id=response.data_id,
+            )
 
-        return result
+            return LeapQCDLSimulator.RunResult(result, info)
+
+        return self._executor.submit(decode)

--- a/dwave/gate/qcdl/leap.py
+++ b/dwave/gate/qcdl/leap.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
+from functools import cached_property
 from typing import Any, Self
 
 import orjson
@@ -66,25 +67,21 @@ class LeapQCDLSimulator:
 
     @property
     def default_solver(self) -> dict[str, str]:
-        """dict: Features used to select the latest accessible QCDL software solver."""
+        """Features used to select the latest accessible QCDL software solver."""
         return dict(supported_problem_types__contains='qcdl',
                     category='software-gate',
                     order_by='-properties.version')
 
-    @property
+    @cached_property
     def properties(self) -> dict[str, Any]:
         """Solver properties as returned by a :term:`SAPI` query.
 
         Solver properties are dependent on the selected solver and subject to
         change; for example, new features may add properties.
         """
-        try:
-            return self._properties
-        except AttributeError:
-            self._properties = properties = self.solver.properties.copy()
-            return properties
+        return self.solver.properties.copy()
 
-    @property
+    @cached_property
     def parameters(self) -> dict[str, list[str]]:
         """Supported parameters.
 
@@ -94,14 +91,10 @@ class LeapQCDLSimulator:
         Solver parameters are dependent on the selected solver and subject to
         change; for example, new features may add parameters.
         """
-        try:
-            return self._parameters
-        except AttributeError:
-            parameters = {param: ['parameters']
-                          for param in self.properties['parameters']}
-            parameters.update(label=[])
-            self._parameters = parameters
-            return parameters
+        parameters = {param: ['parameters']
+                      for param in self.properties['parameters']}
+        parameters.update(label=[])
+        return parameters
 
     def __init__(self, **config):
         r"""Initialize the simulator client instance.

--- a/dwave/gate/qcdl/leap.py
+++ b/dwave/gate/qcdl/leap.py
@@ -1,0 +1,103 @@
+# Copyright 2026 D-Wave
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Provide access to QCDL solvers in Leap."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
+
+import orjson
+from dwave.cloud.client import Client
+
+from dwave.gate.qcdl.qcdl_models import QCDLProgram
+from dwave.gate.results import Result
+
+__all__ = ['LeapQCDLSimulator']
+
+
+class LeapQCDLSimulator:
+    r"""Submits QCDL programs to the Dual-Rail simulator in the Leap service.
+    """
+
+    @property
+    def default_solver(self) -> dict[str, str]:
+        """dict: Features used to select the latest accessible QCDL software solver."""
+        return dict(supported_problem_types__contains='qcdl',
+                    category='software-gate',
+                    order_by='-properties.version')
+
+    def __init__(self, **config):
+        """Initialize the simulator client instance.
+
+        Args:
+            **config:
+                :class:`~dwave.cloud.client.Client` configuration options,
+                including the :term:`solver` selection.
+
+        """
+        # default to short-lived session to prevent resets on slow uploads
+        config.setdefault('connection_close', True)
+
+        # prefer the latest QCDL solver available, but allow for an easy
+        # override on any config level above the defaults (file/env/kwarg)
+        defaults = config.setdefault('defaults', {})
+        if not isinstance(defaults, Mapping):
+            raise TypeError("mapping expected for 'defaults'")
+        defaults.update(solver=self.default_solver)
+
+        self.client = Client.from_config(**config)
+        self.solver = self.client.get_solver()
+
+        self._executor = ThreadPoolExecutor()
+
+    def close(self) -> None:
+        """Close the underlying cloud client to release system resources such as
+        threads.
+
+        The method blocks for all the currently scheduled work (sampling
+        requests) to finish.
+
+        See also:
+            :meth:`~dwave.cloud.client.Client.close`.
+        """
+        self.client.close()
+        self._executor.shutdown(wait=True)
+
+    def run(self, qcdl: QCDLProgram | Mapping[str, Any], **params) -> Future[Result]:
+        """Run the :term:`QCDL` program using the selected Leap simulator,
+        and return the :class:`~dwave.gate.results.Result` in a
+        class:`~concurrent.futures.Future`.
+
+        Args:
+            qcdl:
+                The QCDL circuit to upload and simulate.
+            **params:
+                Job parameters accepted by the simulator (solver).
+
+        Returns:
+            Simulation results.
+
+        """
+        response = self.solver.sample_qcdl(qcdl, **params)
+
+        def decode():
+            answer = orjson.loads(response.answer_data.read())
+            return Result(**answer)
+
+        result = self._executor.submit(decode)
+
+        return result

--- a/dwave/gate/qcdl/leap.py
+++ b/dwave/gate/qcdl/leap.py
@@ -53,7 +53,7 @@ class LeapQCDLSimulator:
 
         .. code-block:: python
 
-            from dwave.gate.leap import LeapQCDLSimulator
+            from dwave.gate.qcdl.leap import LeapQCDLSimulator
 
             simulator = LeapQCDLSimulator()
             future = simulator.run(qcdl_program, shots=100)

--- a/dwave/gate/qcdl/leap.py
+++ b/dwave/gate/qcdl/leap.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any
+from typing import Any, Self
 
 import orjson
 from dwave.cloud.client import Client
@@ -157,6 +157,18 @@ class LeapQCDLSimulator:
         """
         self.client.close()
         self._executor.shutdown(wait=True)
+
+    # note: quickly reimplement `dimod.Scoped` interface here to avoid dimod dependency
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """Release system resources allocated and raise any exception triggered
+        within the runtime context.
+        """
+        self.close()
+        # raise exceptions from the runtime context as they're not handled here
+        return None
 
     def run(self, qcdl: QCDLProgram | Mapping[str, Any], **params) -> Future[Result]:
         """Run the :term:`QCDL` program using the selected Leap simulator,

--- a/dwave/gate/qcdl/leap.py
+++ b/dwave/gate/qcdl/leap.py
@@ -31,6 +31,37 @@ __all__ = ['LeapQCDLSimulator']
 
 class LeapQCDLSimulator:
     r"""Submits QCDL programs to the Dual-Rail simulator in the Leap service.
+
+    Examples:
+        Construct a simple QCDL program:
+
+        .. code-block:: python
+
+            from dwave.gate.qcdl import qcdl
+            from dwave.gate.qcdl.operations import cx, h, measure
+
+            @qcdl(num_qubits=2)
+            def main(q0, q1):
+                h(q0)        # Hadamard gate on q0
+                cx(q0, q1)   # CNOT with q0 as control, q1 as target
+                measure(q0)
+                measure(q1)
+
+            qcdl_program = main()
+
+        Submit it to the Leap QCDL simulator:
+
+        .. code-block:: python
+
+            from dwave.gate.leap import LeapQCDLSimulator
+
+            simulator = LeapQCDLSimulator()
+            future = simulator.run(qcdl_program, shots=100)
+            result = future.result()
+
+        Access measurements and sample counts by calling
+        ``result.measurements`` or ``result.get_counts()`` respectively.
+
     """
 
     @property
@@ -73,12 +104,24 @@ class LeapQCDLSimulator:
             return parameters
 
     def __init__(self, **config):
-        """Initialize the simulator client instance.
+        r"""Initialize the simulator client instance.
 
         Args:
             **config:
                 :class:`~dwave.cloud.client.Client` configuration options,
-                including the :term:`solver` selection.
+                including the :term:`solver` selection. See
+                :ref:`cloud_configuration` section for details.\ [#]_
+
+        .. [#]
+            :ref:`dwave-cloud-client <index_cloud>`'s
+            :meth:`~dwave.cloud.client.Client.get_solvers` method filters solvers
+            you have access to by solver properties, as ``category="software-gate"``
+            and ``supported_problem_type="qcdl"``.
+
+            The default specification for filtering and ordering solvers by features
+            is available as :attr:`.default_solver` property. Explicitly specifying
+            a solver in a configuration file, an environment variable, or keyword
+            arguments overrides this specification.
 
         """
         # default to short-lived session to prevent resets on slow uploads

--- a/dwave/gate/qcdl/leap.py
+++ b/dwave/gate/qcdl/leap.py
@@ -40,6 +40,38 @@ class LeapQCDLSimulator:
                     category='software-gate',
                     order_by='-properties.version')
 
+    @property
+    def properties(self) -> dict[str, Any]:
+        """Solver properties as returned by a :term:`SAPI` query.
+
+        Solver properties are dependent on the selected solver and subject to
+        change; for example, new features may add properties.
+        """
+        try:
+            return self._properties
+        except AttributeError:
+            self._properties = properties = self.solver.properties.copy()
+            return properties
+
+    @property
+    def parameters(self) -> dict[str, list[str]]:
+        """Supported parameters.
+
+        Keys of the returned dict are keyword parameters as returned by a
+        :term:`SAPI` query.
+
+        Solver parameters are dependent on the selected solver and subject to
+        change; for example, new features may add parameters.
+        """
+        try:
+            return self._parameters
+        except AttributeError:
+            parameters = {param: ['parameters']
+                          for param in self.properties['parameters']}
+            parameters.update(label=[])
+            self._parameters = parameters
+            return parameters
+
     def __init__(self, **config):
         """Initialize the simulator client instance.
 
@@ -61,6 +93,12 @@ class LeapQCDLSimulator:
 
         self.client = Client.from_config(**config)
         self.solver = self.client.get_solver()
+
+        # check user-specified solver conforms to our requirements
+        if self.properties.get('category') != 'software-gate':
+            raise ValueError("selected solver is not a gate-model simulator.")
+        if 'qcdl' not in self.solver.supported_problem_types:
+            raise ValueError("selected solver does not support the 'qcdl' problem type.")
 
         self._executor = ThreadPoolExecutor()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "addict",
+    "dwave-cloud-client>=0.14.7,<0.15",
     "numpy>=2,<3",
+    "orjson>=3.11,<4",
     "pydantic>=2,<3",
     "polars>=1.35",
 ]
@@ -40,11 +42,13 @@ Repository = "https://github.com/dwavesystems/dwave-gate.git"
 
 [dependency-groups]
 dev = [
-    "numpy==2.4.6",  # latest that support Python 3.11 as of July 2026
-    "pydantic==2.13.4",  # latest as of July 2026
     "addict==2.4.0",
-    "reno==4.1.0",
+    "dwave-cloud-client==0.14.7",
+    "numpy==2.4.6",     # latest that support Python 3.11 as of July 2026
+    "orjson==3.12",     # latest that supports 3.10--3.15 as of August 2026
     "polars==1.43.1",
+    "pydantic==2.13.4", # latest as of July 2026
+    "reno==4.1.0",
 ]
 docs = [
     # matches dwave-ocean-sdk as of July 2026

--- a/releasenotes/notes/add-leap-qcdl-simulator-7662b3166567df55.yaml
+++ b/releasenotes/notes/add-leap-qcdl-simulator-7662b3166567df55.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Add ``dwave.gate.qcdl.LeapQCDLSimulator``, a client for running QCDL
+    programs on the Dual-Rail simulator hosted in the Leap service. By default,
+    it selects the latest accessible QCDL software solver, with solver
+    selection and connection configurable via standard
+    ``dwave.cloud.client.Client`` options. Its ``run`` method submits a QCDL
+    program together with solver-specific job parameters and returns the
+    decoded ``dwave.gate.results.Result`` in a ``concurrent.futures.Future``.

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -115,18 +115,23 @@ class TestLeapQCDLSimulator:
         decode_response.side_effect = mock_decode_response
 
         try:
-            result = simulator.run(program, shots=num_shots)
+            future = simulator.run(program, shots=num_shots)
 
             # low-level sample_problem called with our program and params
             base_sample_problem.assert_called_with(program, label=None, shots=num_shots)
 
             # decoded answer returned in a Future[Result]
-            assert isinstance(result, concurrent.futures.Future)
-            answer = result.result(timeout=10)
-            assert isinstance(answer, Result)
-            assert answer.num_shots == mock_answer['num_shots']
-            assert answer.num_qubits == mock_answer['num_qubits']
-            assert answer.simulated_qcdl == mock_answer['simulated_qcdl']
+            assert isinstance(future, concurrent.futures.Future)
+            runresult = future.result(timeout=10)
+            assert isinstance(runresult, LeapQCDLSimulator.RunResult)
+            result = runresult.result
+            assert isinstance(result, Result)
+            assert result.num_shots == mock_answer['num_shots']
+            assert result.num_qubits == mock_answer['num_qubits']
+            assert result.simulated_qcdl == mock_answer['simulated_qcdl']
+            info = runresult.info
+            assert isinstance(info, dict)
+            assert info['problem_id'] == mock_problem_id
         finally:
             simulator.close()
 

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -137,3 +137,12 @@ class TestLeapQCDLSimulator:
                 simulator.client, 'close', wraps=simulator.client.close) as client_close:
             simulator.close()
         client_close.assert_called_once()
+
+    @unittest.mock.patch('dwave.gate.qcdl.leap.Client', mock_client_factory)
+    def test_context_mgr(self):
+        simulator = LeapQCDLSimulator()
+        with unittest.mock.patch.object(
+                simulator.client, 'close', wraps=simulator.client.close) as client_close:
+            with simulator:
+                pass
+        client_close.assert_called_once()

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -130,8 +130,10 @@ class TestLeapQCDLSimulator:
         finally:
             simulator.close()
 
-    @unittest.mock.patch('dwave.gate.qcdl.leap.Client')
-    def test_close(self, mock_client):
+    @unittest.mock.patch('dwave.gate.qcdl.leap.Client', mock_client_factory)
+    def test_close(self):
         simulator = LeapQCDLSimulator()
-        simulator.close()
-        mock_client.from_config.return_value.close.assert_called_once()
+        with unittest.mock.patch.object(
+                simulator.client, 'close', wraps=simulator.client.close) as client_close:
+            simulator.close()
+        client_close.assert_called_once()

--- a/tests/test_leap.py
+++ b/tests/test_leap.py
@@ -1,0 +1,137 @@
+# Copyright 2026 D-Wave
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Unit tests for LeapQCDLSimulator in leap.py, with the cloud API mocked."""
+
+import concurrent.futures
+import unittest.mock
+
+import orjson
+import pytest
+
+from dwave.cloud.client import Client
+from dwave.cloud.computation import Future
+from dwave.cloud.solver import StructuredSolver, QCDLSolver
+from dwave.cloud.testing.mocks import qpu_clique_solver_data, qcdl_solver_data
+
+from dwave.gate.qcdl import LeapQCDLSimulator, qcdl
+from dwave.gate.results import Result
+
+
+class mock_client_factory:
+    """Stand-in for :class:`dwave.cloud.client.Client` that serves a static
+    list of mock solvers, so solver selection runs client-side, unmodified.
+    """
+
+    @classmethod
+    def from_config(cls, **kwargs):
+        # keep instantiation local, so we can later mock BaseUnstructuredSolver
+        qcdl_sim_v1 = QCDLSolver(client=None, data=qcdl_solver_data(
+            name='qcdl_sim_v1', category='software-gate', version='0.1'))
+        qcdl_sim_v2 = QCDLSolver(client=None, data=qcdl_solver_data(
+            name='qcdl_sim_v2', category='software-gate', version='0.2'))
+        qcdl_qpu = QCDLSolver(client=None, data=qcdl_solver_data(
+            name='qcdl_qpu', category='qpu-gate'))
+        ising_qpu = StructuredSolver(client=None, data=qpu_clique_solver_data(4))
+        kwargs.setdefault('endpoint', 'mock')
+        kwargs.setdefault('token', 'mock')
+        client = Client(**kwargs)
+        client._fetch_solvers = \
+            lambda **kwargs: [ising_qpu, qcdl_sim_v1, qcdl_sim_v2, qcdl_qpu]
+        return client
+
+
+class TestLeapQCDLSimulator:
+
+    @unittest.mock.patch('dwave.gate.qcdl.leap.Client', mock_client_factory)
+    def test_solver_selection(self):
+        simulator = LeapQCDLSimulator()
+        try:
+            properties = simulator.solver.properties
+            assert 'qcdl' in properties.get('supported_problem_types', [])
+            assert properties.get('category') == 'software-gate'
+            # the latest of the two matching solvers is preferred
+            assert properties.get('version') == '0.2'
+        finally:
+            simulator.close()
+
+    @unittest.mock.patch('dwave.gate.qcdl.leap.Client', mock_client_factory)
+    def test_solver_selection_override(self):
+        # explicit solver selection takes precedence over the defaults
+        simulator = LeapQCDLSimulator(solver=dict(name='qcdl_sim_v1'))
+        try:
+            assert simulator.solver.identity.name == 'qcdl_sim_v1'
+        finally:
+            simulator.close()
+
+    def test_invalid_defaults(self):
+        with pytest.raises(TypeError):
+            LeapQCDLSimulator(defaults='not-a-mapping')
+
+    @unittest.mock.patch('dwave.gate.qcdl.leap.Client', mock_client_factory)
+    @unittest.mock.patch('dwave.cloud.solver.BaseUnstructuredSolver.sample_problem')
+    @unittest.mock.patch('dwave.cloud.solver.QCDLSolver.decode_response')
+    def test_run(self, decode_response, base_sample_problem):
+        simulator = LeapQCDLSimulator()
+
+        # create a program
+        @qcdl()
+        def circuit(q0):
+            q0.x()
+            q0.measure()
+
+        program = circuit()
+
+        num_qubits = 1
+        num_shots = 100
+
+        mock_problem_id = '321'
+        mock_answer = dict(num_shots=num_shots, num_qubits=num_qubits, simulated_qcdl='input')
+
+        # note: instead of simply mocking `simulator.solver`, we mock a set of
+        # solver methods minimally required to fully test `QCDLSolver.sample_qcdl`
+
+        base_sample_problem.return_value = Future(
+            solver=simulator.solver, id_=mock_problem_id)
+        base_sample_problem.return_value._set_message({"answer": {}})
+
+        def mock_decode_response(msg, answer_data):
+            # write the serialized answer to the "received" answer_data
+            answer_data.write(orjson.dumps(mock_answer))
+            answer_data.seek(0)
+            return {'problem_type': 'qcdl', 'answer': answer_data}
+
+        decode_response.side_effect = mock_decode_response
+
+        try:
+            result = simulator.run(program, shots=num_shots)
+
+            # low-level sample_problem called with our program and params
+            base_sample_problem.assert_called_with(program, label=None, shots=num_shots)
+
+            # decoded answer returned in a Future[Result]
+            assert isinstance(result, concurrent.futures.Future)
+            answer = result.result(timeout=10)
+            assert isinstance(answer, Result)
+            assert answer.num_shots == mock_answer['num_shots']
+            assert answer.num_qubits == mock_answer['num_qubits']
+            assert answer.simulated_qcdl == mock_answer['simulated_qcdl']
+        finally:
+            simulator.close()
+
+    @unittest.mock.patch('dwave.gate.qcdl.leap.Client')
+    def test_close(self, mock_client):
+        simulator = LeapQCDLSimulator()
+        simulator.close()
+        mock_client.from_config.return_value.close.assert_called_once()


### PR DESCRIPTION
In this PR we implement the higher-level, sampler-like interface for the QCDL solver in Leap.

The class name, `LeapQCDLSimulator` is up for discussion. @qci-amos initially suggested `QCDLSimulator`, I added `Leap` for consistency with other Ocean samplers in Leap.

We use `run()` method instead of `sample()` for consistency with other gate-model libraries.

~One thing I'll probably change is the result type contained in the `run()`-returned future. Currently, that's just `dwave.gate.results.Result`, but for convenience we should add some metadata, like the timing info returned, the job id, etc. We could model the `SampleResult` returned by the Stride sampler.~
(Edit: done in b948ce14dfb217bda896844524b2eae28d97fc1a.)

In addition, we could enrich the returned future with progress-tracking attributes/methods (e.g. upload in progress, upload completed, problem submitted, pending, done, etc).

I'll leave the latter for a follow-up PR.

#### Usage Example

```python
from dwave.gate.qcdl.leap import LeapQCDLSimulator

simulator = LeapQCDLSimulator(profile='test')
future = simulator.run(qcdl_program, shots=100)
result = future.result()

measurements = result.measurements
```

#### AI Generation Disclosure
Used Claude Fable 5 for the first draft of tests (translation of NLSampler tests to the QCDL use case).