### PR TITLE
Add job submission and solver properties & parameters

### DIFF
--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1304,8 +1304,10 @@ qpu
 
 The QPU to simulate, formatted as a string.
 
-Specified value must be one of the values of the
-:ref:`property_drsim_supported_qpu_strings` property.
+Specified value must be one of the following values:
+
+*   ``simulator``: Ideal simulator.
+*   ``DR17``: Dual-rail QPU with 17 qubits.
 
 Default is to simulate the QPU specified by the
 :ref:`property_drsim_default_qpu` property.
@@ -1421,6 +1423,212 @@ This example applies a noise model.
 
 Simulator Properties
 --------------------
+
+.. _property_drsim_category:
+
+category
+~~~~~~~~
+
+Type of solver, as a string.
+
+*   ``software-gate``: Gate-model simulator.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_default_noise_model:
+
+default_noise_model
+~~~~~~~~~~~~~~~~~~~
+
+Default setting for the application of a noise model, as a Boolean.
+
+*   ``True``: A noise model is applied.
+*   ``False``: Simulates an ideal QPU.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_default_qpu:
+
+default_qpu
+~~~~~~~~~~~
+
+Default selection of the QPU to simulate, as a string.
+
+*   ``simulator``: Ideal simulator.
+*   ``DR17``: Dual-rail QPU with 17 qubits.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_default_repeat_until_shots_requested:
+
+default_repeat_until_shots_requested
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default setting, as a Boolean, for rerunning the circuit until the requested
+number of measurements is accumulated.
+
+*   ``True``: Repeatedly rerun the circuit.
+*   ``False``: Run the circuit the number of times set by the
+    :ref:`parameter_drsim_shots` parameter.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_default_shots:
+
+default_shots
+~~~~~~~~~~~~~
+
+Default setting for the number of times to run the circuit, as an integer.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_default_time_limit:
+
+default_time_limit
+~~~~~~~~~~~~~~~~~~
+
+Default maximum runtime, in seconds, the solver is allowed to work on the
+given program, as a float.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_default_transpile:
+
+default_transpile
+~~~~~~~~~~~~~~~~~
+
+Default setting, as a Boolean, for transpiling the submitted QCDL program.
+
+*   ``True``: Transpile the program.
+*   ``False``: Run the circuit exactly as specified in the submitted
+    QCDL or return an error
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_max_shots:
+
+max_shots
+~~~~~~~~~
+
+Maximum number of times the circuit can be executed, as an integer.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_maximum_time_limit_s:
+
+maximum_time_limit_s
+~~~~~~~~~~~~~~~~~~~~
+
+Maximum time you can specify that your submitted circuit be executed, as a
+float.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_minimum_time_limit_s:
+
+minimum_time_limit_s
+~~~~~~~~~~~~~~~~~~~~
+
+Minimum time you can specify that your submitted circuit be executed, as a
+float.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
+
+.. _property_drsim_quota_conversion_rate:
+
+quota_conversion_rate
+~~~~~~~~~~~~~~~~~~~~~
+
+Rate at which user or project quota is consumed for the solver as a
+ratio to QPU solver usage. Different solver types may consume quota
+at different rates.
+
+Time is deducted from your quota according to:
+
+.. math::
+
+    \frac{num\_seconds}{quota\_conversion\_rate}
+
+See the :ref:`leap_hybrid_usage_charges` section for more information.
+
+Example
+-------
+
+>>> from dwave.system import DWaveSampler
+...
+>>> sampler = DWaveSampler()
+>>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
+0.0
 
 .. list-table::
     :header-rows: 1

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1210,8 +1210,8 @@ Guidance on Mirroring
 
 .. _qcdl_simulator:
 
-Simulator
-=========
+QPU Simulator
+=============
 
 the |cloud|_ service provides a Monte Carlo simulator of QCDL programs. This is
 an ideal simulator built on top of Qiskit's
@@ -1235,11 +1235,13 @@ number of shots; however, its operation is
 
 The simulator in the |cloud|_ service supports two modes of simulations:
 
-*   Statevector Simulation (solver parameter `qpu=simulator`)
+*   Statevector Simulation (solver parameter :ref:`parameter_drsim_noise_model`
+    set to ``False``)
 
     This simulation is useful during initial testing of
     QCDL programs before introducing noise.
-*   Dual-Rail Erasure Simulation (solver parameter `qpu=DR17`)
+*   Dual-Rail Erasure Simulation (solver parameter
+    :ref:`parameter_drsim_noise_model` set to ``True``)
 
     This simulation is useful for exploring the impact of erasures on QCDL
     programs. It represents the quantum state as a Statevector with an array of
@@ -1255,16 +1257,13 @@ The following table compares these two simulation modes.
     *   -   Characteristic
         -   Statevector Simulation
         -   Dual-Rail Erasure Simulation
-    *   -   Run time
+    *   -   Runtime.
         -   Scales as :math:`O(2^n)` where :math:`n` is the number of qubits.
         -   Slightly slower than statevector simulation but same scaling.
-    *   -   Topology
-        -   No restrictions.
-        -   Depends on the noise model and the coupling map, options which model the selected QPU by default.
-    *   -   Depends on the noise model but which will represent the selected QPU by default.
+    *   -   Supported gates.
         -   All basis gates available in Qiskit (no transpilation require).
         -   Subset of basis gates (transpilation required).
-    *   -   Support for errors
+    *   -   Support for errors.
         -   No support.
         -   Supports the ``mced`` instruction to detect if the qubit has been
             erased, and the ``leak`` and ``seep`` instructions to simulate
@@ -1282,9 +1281,9 @@ dual-rail quantum computer by executing gate-model programs formulated as QCDL.
 The following documentation describes how to work with the |cloud|_ service:
 
 *   The :ref:`index_leap_sapi` section describes the |cloud|_ service.
-*   The :ref:`ocean_install` section explains how to install Ocean software.
 *   The :ref:`ocean_leap_authorization` section walks you through authorizing
     your Ocean client to access the simulator in the |cloud|_ service.
+*   The :ref:`ocean_install` section explains how to install Ocean software.
 
 Descriptions of the supported parameters and simulator properties are provided
 in the :ref:`qcdl_simulator_parameters` and :ref:`qcdl_simulator_properties`
@@ -1312,21 +1311,23 @@ The example below submits the following
 
     simulator_job_submission = bell_program()
 
-The program above is submitted to a dual-rail simulator, ``DR17``, in the
-|cloud|_ service.
+Submit the program above to a simulator for a dual-rail QPU with 17 qubits,
+``DRsim_17qubits``, in the |cloud|_ service.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     qpu=`DR17`)
+...     qpu='DRsim_17qubits')
 >>> result = future.result().result         # doctest: +SKIP
+
+.. todo:: describe the results
 
 .. _qcdl_simulator_parameters:
 
 Simulator Parameters
---------------------
+====================
 
 The examples in this section submit the QCDL program defined in the
 :ref:`qcdl_submitting_programs_example` section.
@@ -1335,17 +1336,18 @@ The examples in this section submit the QCDL program defined in the
 .. _parameter_drsim_noise_model:
 
 noise_model
-~~~~~~~~~~~
+-----------
 
 Boolean flag that applies a noise model.
 
 *   ``noise_model=True``: Apply a noise model.
-*   ``noise_model=False``: Do not apply a noise model.
+*   ``noise_model=False``: Do not apply a noise model (simulate an ideal QPU,
+    as described in the :ref:`qcdl_simulator` section).
 
-Default is the value specified by the :ref:`property_drsim_default_noise_model`
+The default value is specified by the :ref:`property_drsim_default_noise_model`
 property.
 
-This example applies a noise model on the simulator.
+This example applies a noise model for the program submitted to the simulator.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1358,45 +1360,51 @@ This example applies a noise model on the simulator.
 .. _parameter_drsim_qpu:
 
 qpu
-~~~
+---
 
 The QPU to simulate, formatted as a string.
 
-Specified value must be one of the following values:
+The following values are supported:
 
-*   ``simulator``: Ideal simulator.
-*   ``DR17``: Dual-rail QPU with 17 qubits.
+*   ``DRsim_17qubits``: Dual-rail QPU with 17 qubits.
+*   ``DRsim_21qubits``: Dual-rail QPU with 21 qubits.
 
-Default is to simulate the QPU specified by the
+The default QPU to simulate is specified by the
 :ref:`property_drsim_default_qpu` property.
 
-This example selects the ``DR17`` QPU simulator.
+This example submits a QCDL program to a dual-rail QPU simulator with 17 qubits,
+``DRsim_17qubits`` .
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     qpu='DR17')
+...     qpu='DRsim_17qubits')
 >>> result = future.result().result         # doctest: +SKIP
 
 
 .. _parameter_drsim_repeat_until_shots_requested:
 
 repeat_until_shots_requested
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 Boolean flag to run the circuit repeatedly until the requested number of
-measurements are accumulated.
+measurements, set by the :ref:`parameter_drsim_shots` parameter, are
+accumulated, even under noisy conditions.
 
 *   ``repeat_until_shots_requested=True``: Repeatedly run the circuit until
     the requested number of measurements, set by the
-    :ref:`parameter_drsim_shots` parameter, is accumulated.
+    :ref:`parameter_drsim_shots` parameter, is accumulated. Under noisy
+    conditions the circuit might be executed a greater number of times than set
+    by the :ref:`parameter_drsim_shots` parameter.
 *   ``repeat_until_shots_requested=False``: Run the circuit the number of times
-    set by the :ref:`parameter_drsim_shots` parameter.
+    set by the :ref:`parameter_drsim_shots` parameter. Under noisy conditions,
+    fewer measurements than requested by the :ref:`parameter_drsim_shots`
+    parameter might be accumulated.
 
-Default is to run the circuit the number of times set by the
-:ref:`parameter_drsim_shots` parameter.
+The default value is set by the
+:ref:`property_drsim_default_repeat_until_shots_requested` property.
 
 This example repeatedly executes the circuit to accumulate 10 measurements.
 
@@ -1412,7 +1420,7 @@ This example repeatedly executes the circuit to accumulate 10 measurements.
 .. _parameter_drsim_shots:
 
 shots
-~~~~~
+-----
 
 The number of times to run the circuit, formatted as an integer.
 
@@ -1435,7 +1443,7 @@ This example executes the circuit 15 times.
 .. _parameter_drsim_time_limit:
 
 time_limit
-~~~~~~~~~~
+----------
 
 Specifies the maximum runtime, in seconds, the solver is allowed to work on the
 given program. Can be a float or integer.
@@ -1460,7 +1468,7 @@ This example sets a maximum runtime of 20 seconds.
 .. _parameter_drsim_transpile:
 
 transpile
-~~~~~~~~~
+---------
 
 Boolean flag to rewrite the submitted QCDL circuit to use the QPU's supported
 basis gates and topology.
@@ -1487,19 +1495,16 @@ simulator.
 .. _qcdl_simulator_properties:
 
 Simulator Properties
---------------------
+====================
 
 .. _property_drsim_category:
 
 category
-~~~~~~~~
+--------
 
 Type of solver, as a string.
 
 *   ``software-gate``: Gate-model simulator.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1510,15 +1515,12 @@ Example
 .. _property_drsim_default_noise_model:
 
 default_noise_model
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Default setting for the application of a noise model, as a Boolean.
 
 *   ``True``: A noise model is applied.
 *   ``False``: Simulates an ideal QPU.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1529,26 +1531,23 @@ False
 .. _property_drsim_default_qpu:
 
 default_qpu
-~~~~~~~~~~~
+-----------
 
 Default selection of the QPU to simulate, as a string.
 
-*   ``simulator``: Ideal simulator.
-*   ``DR17``: Dual-rail QPU with 17 qubits.
-
-Example
--------
+*   ``DRsim_17qubits``: Dual-rail QPU with 17 qubits.
+*   ``DRsim_21qubits``: Dual-rail QPU with 21 qubits.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> simulator.properties["default_qpu"]     # doctest: +SKIP
-'simulator'
+'DRsim_21qubits'
 
 .. _property_drsim_default_repeat_until_shots_requested:
 
 default_repeat_until_shots_requested
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 
 Default setting, as a Boolean, for rerunning the circuit until the requested
 number of measurements is accumulated.
@@ -1556,9 +1555,6 @@ number of measurements is accumulated.
 *   ``True``: Repeatedly rerun the circuit.
 *   ``False``: Run the circuit the number of times set by the
     :ref:`parameter_drsim_shots` parameter.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1569,12 +1565,9 @@ False
 .. _property_drsim_default_shots:
 
 default_shots
-~~~~~~~~~~~~~
+-------------
 
 Default setting for the number of times to run the circuit, as an integer.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1585,13 +1578,10 @@ Example
 .. _property_drsim_default_time_limit:
 
 default_time_limit
-~~~~~~~~~~~~~~~~~~
+------------------
 
 Default maximum runtime, in seconds, the solver is allowed to work on the
 given program, as a float.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1602,7 +1592,7 @@ Example
 .. _property_drsim_default_transpile:
 
 default_transpile
-~~~~~~~~~~~~~~~~~
+-----------------
 
 Default setting, as a Boolean, for transpiling the submitted QCDL program.
 
@@ -1610,24 +1600,33 @@ Default setting, as a Boolean, for transpiling the submitted QCDL program.
 *   ``False``: Run the circuit exactly as specified in the submitted
     QCDL or return an error
 
-Example
--------
-
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["default_transpile"]       # doctest: +SKIP
 True
 
+.. _property_drsim_max_num_qubits:
+
+max_num_qubits
+--------------
+
+Maximum number of qubits for QCDL circuits, as an integer.
+
+.. note:: Transpilation can introduce and remove qubits from your QCDL.
+
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+...
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> simulator.properties["max_num_qubits"]       # doctest: +SKIP
+21
+
 .. _property_drsim_max_shots:
 
 max_shots
-~~~~~~~~~
+---------
 
 Maximum number of times the circuit can be executed, as an integer.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1638,13 +1637,10 @@ Example
 .. _property_drsim_maximum_time_limit_s:
 
 maximum_time_limit_s
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Maximum time you can specify that your submitted circuit be executed, as a
 float.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1655,13 +1651,10 @@ Example
 .. _property_drsim_minimum_time_limit_s:
 
 minimum_time_limit_s
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Minimum time you can specify that your submitted circuit be executed, as a
 float.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1672,7 +1665,7 @@ Example
 .. _property_drsim_quota_conversion_rate:
 
 quota_conversion_rate
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 Rate at which user or project quota is consumed for the solver as a
 ratio to QPU solver usage. Different solver types may consume quota
@@ -1685,9 +1678,6 @@ Time is deducted from your quota according to:
     \frac{num\_seconds}{quota\_conversion\_rate}
 
 See the :ref:`leap_hybrid_usage_charges` section for more information.
-
-Example
--------
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1370,14 +1370,14 @@ Specified value must be one of the following values:
 Default is to simulate the QPU specified by the
 :ref:`property_drsim_default_qpu` property.
 
-This example applies a noise model.
+This example selects the ``DR17`` QPU simulator.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     noise_model=True)
+...     qpu='DR17')
 >>> result = future.result().result         # doctest: +SKIP
 
 
@@ -1398,14 +1398,15 @@ measurements are accumulated.
 Default is to run the circuit the number of times set by the
 :ref:`parameter_drsim_shots` parameter.
 
-This example applies a noise model.
+This example repeatedly executes the circuit to accumulate 10 measurements.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     noise_model=True)
+...     shots=10,
+...     repeat_until_shots_requested=True)
 >>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_shots:
@@ -1421,14 +1422,14 @@ The specified value must not exceed the value of the
 Default is to run the circuit the number of times specified by the
 :ref:`property_drsim_default_shots` property.
 
-This example applies a noise model.
+This example executes the circuit 15 times.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     noise_model=True)
+...     shots=10)
 >>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_time_limit:
@@ -1446,14 +1447,14 @@ The specified time must be between the values of the
 Default is to run the circuit for the time specified by the
 :ref:`property_drsim_default_time_limit` property.
 
-This example applies a noise model.
+This example sets a maximum runtime of 20 seconds.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     noise_model=True)
+...     time_limit=20)
 >>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_transpile:
@@ -1471,14 +1472,15 @@ basis gates and topology.
 Default is the value specified by the :ref:`property_drsim_default_transpile`
 property.
 
-This example applies a noise model.
+This example requires that the QCDL circuit be submitted as written to the
+simulator.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     noise_model=True)
+...     transpile=False)
 >>> result = future.result().result         # doctest: +SKIP
 
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1391,7 +1391,8 @@ repeat_until_shots_requested
 
 Boolean flag to run the circuit repeatedly until the requested number of
 measurements, set by the :ref:`parameter_drsim_shots` parameter, are
-accumulated, even under noisy conditions.
+accumulated, even under noisy conditions, where the accumulated measurements do
+not include erasures (see the :ref:`qcdl_basic_result_records` section).
 
 *   ``repeat_until_shots_requested=True``: Repeatedly run the circuit until
     the requested number of measurements, set by the
@@ -1405,6 +1406,12 @@ accumulated, even under noisy conditions.
 
 The default value is set by the
 :ref:`property_drsim_default_repeat_until_shots_requested` property.
+
+If runtime exceeds the value you specified in the
+:ref:`parameter_drsim_time_limit` parameter, or the maximum allowed runtime
+value of the :ref:`property_drsim_maximum_time_limit_s` property, execution
+terminates. The maximum number of times the circuit is run cannot exceed the
+value specified by the :ref:`property_drsim_max_shots` property.
 
 This example repeatedly executes the circuit to accumulate 10 measurements.
 
@@ -1422,12 +1429,17 @@ This example repeatedly executes the circuit to accumulate 10 measurements.
 shots
 -----
 
-The number of times to run the circuit, formatted as an integer.
+The number of measurements to run, formatted as an integer.
+
+Your QCDL program is executed once for each requested measurement.
 
 The specified value must not exceed the value of the
-:ref:`property_drsim_max_shots` property.
+:ref:`property_drsim_max_shots` property. Execution time is limited by the
+the value you specified in the :ref:`parameter_drsim_time_limit` parameter, or
+the maximum allowed runtime value of the
+:ref:`property_drsim_maximum_time_limit_s` property.
 
-Default is to run the circuit the number of times specified by the
+The default value is to measure the number of times specified by the
 :ref:`property_drsim_default_shots` property.
 
 This example executes the circuit 15 times.
@@ -1437,7 +1449,7 @@ This example executes the circuit 15 times.
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     shots=10)
+...     shots=15)
 >>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_time_limit:
@@ -1452,7 +1464,7 @@ The specified time must be between the values of the
 :ref:`property_drsim_maximum_time_limit_s` and
 :ref:`property_drsim_minimum_time_limit_s` properties.
 
-Default is to run the circuit for the time specified by the
+The default runtime limit is specified by the
 :ref:`property_drsim_default_time_limit` property.
 
 This example sets a maximum runtime of 20 seconds.
@@ -1471,13 +1483,14 @@ transpile
 ---------
 
 Boolean flag to rewrite the submitted QCDL circuit to use the QPU's supported
-basis gates and topology.
+basis gates and topology, as described in the :ref:`qcdl_basic_transpilation`
+section.
 
 *   ``transpile=True``: Transpile the circuit.
 *   ``transpile=False``: Run the circuit exactly as specified in the submitted
     QCDL or return an error.
 
-Default is the value specified by the :ref:`property_drsim_default_transpile`
+The default value is specified by the :ref:`property_drsim_default_transpile`
 property.
 
 This example requires that the QCDL circuit be submitted as written to the
@@ -1520,7 +1533,8 @@ default_noise_model
 Default setting for the application of a noise model, as a Boolean.
 
 *   ``True``: A noise model is applied.
-*   ``False``: Simulates an ideal QPU.
+*   ``False``: Simulates an ideal QPU, as described in the
+    :ref:`qcdl_simulator` section.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1550,7 +1564,8 @@ default_repeat_until_shots_requested
 ------------------------------------
 
 Default setting, as a Boolean, for rerunning the circuit until the requested
-number of measurements is accumulated.
+number of measurements is accumulated, where the accumulated measurements do not
+include erasures (see the :ref:`qcdl_basic_result_records` section).
 
 *   ``True``: Repeatedly rerun the circuit.
 *   ``False``: Run the circuit the number of times set by the
@@ -1567,7 +1582,9 @@ False
 default_shots
 -------------
 
-Default setting for the number of times to run the circuit, as an integer.
+Default setting for the number of measurements to run (times to execute your
+QCDL circuit), as an integer. With dual-rail QPUs, a measurement result can be a
+"splat" (see the :ref:`qcdl_basic_measurements` section).
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1594,11 +1611,12 @@ given program, as a float.
 default_transpile
 -----------------
 
-Default setting, as a Boolean, for transpiling the submitted QCDL program.
+Default setting, as a Boolean, for :ref:`transpiling <qcdl_basic_transpilation>`
+the submitted QCDL program.
 
 *   ``True``: Transpile the program.
 *   ``False``: Run the circuit exactly as specified in the submitted
-    QCDL or return an error
+    QCDL or return an error.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1613,7 +1631,8 @@ max_num_qubits
 
 Maximum number of qubits for QCDL circuits, as an integer.
 
-.. note:: Transpilation can introduce and remove qubits from your QCDL.
+.. note:: :ref:`Transpilation <qcdl_basic_transpilation>` can add and remove
+    qubits in your QCDL.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1639,8 +1658,12 @@ Maximum number of times the circuit can be executed, as an integer.
 maximum_time_limit_s
 --------------------
 
-Maximum time you can specify that your submitted circuit be executed, as a
-float.
+Maximum time, in seconds as a float, that your submitted circuit can run.
+
+This value limits the range of values you can set on the
+:ref:`parameter_drsim_time_limit` parameter and also limits the runtime allowed
+for a program submitted with the
+:ref:`parameter_drsim_repeat_until_shots_requested` set to true.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1653,8 +1676,8 @@ float.
 minimum_time_limit_s
 --------------------
 
-Minimum time you can specify that your submitted circuit be executed, as a
-float.
+Minimum time, in seconds as a float, you can specify for the runtime limit (the
+:ref:`parameter_drsim_time_limit` parameter) on your submitted circuit.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1667,9 +1690,8 @@ float.
 quota_conversion_rate
 ---------------------
 
-Rate at which user or project quota is consumed for the solver as a
-ratio to QPU solver usage. Different solver types may consume quota
-at different rates.
+Rate at which user or project quota is consumed for the solver as a ratio to
+QPU solver usage. Different solver types may consume quota at different rates.
 
 Time is deducted from your quota according to:
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1270,10 +1270,67 @@ The following table compares these two simulation modes.
             erased, and the ``leak`` and ``seep`` instructions to simulate
             leakage and seepage errors.
 
+
+.. _qcdl_submitting_programs:
+
+Submitting Programs
+===================
+
+The gate-model simulator in the |cloud|_ service is intended to simulate the
+dual-rail quantum computer by executing gate-model programs formulated as QCDL.
+
+The following documentation describes how to work with the |cloud|_ service:
+
+*   The :ref:`index_leap_sapi` section describes the |cloud|_ service.
+*   The :ref:`ocean_install` section explains how to install Ocean software.
+*   The :ref:`ocean_leap_authorization` section walks you through authorizing
+    your Ocean client to access the simulator in the |cloud|_ service.
+
+Descriptions of the supported parameters and simulator properties are provided
+in the :ref:`qcdl_simulator_parameters` and :ref:`qcdl_simulator_properties`
+sections.
+
+.. _qcdl_submitting_programs_example:
+
+Example Submission
+------------------
+
+The example below submits the following
+`Bell state <https://en.wikipedia.org/wiki/Bell_state>`_ QCDL program.
+
+.. testcode::
+
+    from dwave.gate.qcdl import qcdl
+    from dwave.gate.qcdl.operations import cx, h, measure
+
+    @qcdl(2)
+    def bell_program(q0, q1):
+        h(q0)
+        cx(q0, q1)
+        measure(q0)
+        measure(q1)
+
+    simulator_job_submission = bell_program()
+
+The program above is submitted to a dual-rail simulator, ``DR17``, in the
+|cloud|_ service.
+
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+...
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> future = simulator.run(                 # doctest: +SKIP
+...     simulator_job_submission,
+...     qpu=`DR17`)
+>>> result = future.result().result         # doctest: +SKIP
+
 .. _qcdl_simulator_parameters:
 
 Simulator Parameters
 --------------------
+
+The examples in this section submit the QCDL program defined in the
+:ref:`qcdl_submitting_programs_example` section.
+
 
 .. _parameter_drsim_noise_model:
 
@@ -1288,14 +1345,15 @@ Boolean flag that applies a noise model.
 Default is the value specified by the :ref:`property_drsim_default_noise_model`
 property.
 
-This example applies a noise model.
+This example applies a noise model on the simulator.
 
->>> from dwave.system import EmbeddingComposite, DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = EmbeddingComposite(DWaveSampler())
->>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
->>> sampleset = sampler.sample_ising({}, J, num_reads=100,
-...                                  flux_drift_compensation=False)
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> future = simulator.run(                 # doctest: +SKIP
+...     simulator_job_submission,
+...     noise_model=True)
+>>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_qpu:
 
@@ -1314,12 +1372,13 @@ Default is to simulate the QPU specified by the
 
 This example applies a noise model.
 
->>> from dwave.system import EmbeddingComposite, DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = EmbeddingComposite(DWaveSampler())
->>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
->>> sampleset = sampler.sample_ising({}, J, num_reads=100,
-...                                  flux_drift_compensation=False)
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> future = simulator.run(                 # doctest: +SKIP
+...     simulator_job_submission,
+...     noise_model=True)
+>>> result = future.result().result         # doctest: +SKIP
 
 
 .. _parameter_drsim_repeat_until_shots_requested:
@@ -1341,12 +1400,13 @@ Default is to run the circuit the number of times set by the
 
 This example applies a noise model.
 
->>> from dwave.system import EmbeddingComposite, DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = EmbeddingComposite(DWaveSampler())
->>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
->>> sampleset = sampler.sample_ising({}, J, num_reads=100,
-...                                  flux_drift_compensation=False)
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> future = simulator.run(                 # doctest: +SKIP
+...     simulator_job_submission,
+...     noise_model=True)
+>>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_shots:
 
@@ -1363,12 +1423,13 @@ Default is to run the circuit the number of times specified by the
 
 This example applies a noise model.
 
->>> from dwave.system import EmbeddingComposite, DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = EmbeddingComposite(DWaveSampler())
->>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
->>> sampleset = sampler.sample_ising({}, J, num_reads=100,
-...                                  flux_drift_compensation=False)
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> future = simulator.run(                 # doctest: +SKIP
+...     simulator_job_submission,
+...     noise_model=True)
+>>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_time_limit:
 
@@ -1387,12 +1448,13 @@ Default is to run the circuit for the time specified by the
 
 This example applies a noise model.
 
->>> from dwave.system import EmbeddingComposite, DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = EmbeddingComposite(DWaveSampler())
->>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
->>> sampleset = sampler.sample_ising({}, J, num_reads=100,
-...                                  flux_drift_compensation=False)
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> future = simulator.run(                 # doctest: +SKIP
+...     simulator_job_submission,
+...     noise_model=True)
+>>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_transpile:
 
@@ -1411,12 +1473,13 @@ property.
 
 This example applies a noise model.
 
->>> from dwave.system import EmbeddingComposite, DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = EmbeddingComposite(DWaveSampler())
->>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
->>> sampleset = sampler.sample_ising({}, J, num_reads=100,
-...                                  flux_drift_compensation=False)
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> future = simulator.run(                 # doctest: +SKIP
+...     simulator_job_submission,
+...     noise_model=True)
+>>> result = future.result().result         # doctest: +SKIP
 
 
 .. _qcdl_simulator_properties:
@@ -1436,11 +1499,11 @@ Type of solver, as a string.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()     # doctest: +SKIP
+>>> simulator.properties["category"]    # doctest: +SKIP
+'software-gate'
 
 .. _property_drsim_default_noise_model:
 
@@ -1455,11 +1518,11 @@ Default setting for the application of a noise model, as a Boolean.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
+>>> simulator.properties["default_noise_model"]     # doctest: +SKIP
+False
 
 .. _property_drsim_default_qpu:
 
@@ -1474,11 +1537,11 @@ Default selection of the QPU to simulate, as a string.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> simulator.properties["default_qpu"]     # doctest: +SKIP
+'simulator'
 
 .. _property_drsim_default_repeat_until_shots_requested:
 
@@ -1495,11 +1558,11 @@ number of measurements is accumulated.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()                                 # doctest: +SKIP
+>>> simulator.properties["default_repeat_until_shots_requested"]    # doctest: +SKIP
+False
 
 .. _property_drsim_default_shots:
 
@@ -1511,11 +1574,11 @@ Default setting for the number of times to run the circuit, as an integer.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> simulator.properties["default_shots"]   # doctest: +SKIP
+1
 
 .. _property_drsim_default_time_limit:
 
@@ -1528,11 +1591,11 @@ given program, as a float.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
+>>> simulator.properties["default_time_limit"]      # doctest: +SKIP
+2700
 
 .. _property_drsim_default_transpile:
 
@@ -1548,11 +1611,11 @@ Default setting, as a Boolean, for transpiling the submitted QCDL program.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
+>>> simulator.properties["default_transpile"]       # doctest: +SKIP
+True
 
 .. _property_drsim_max_shots:
 
@@ -1564,11 +1627,11 @@ Maximum number of times the circuit can be executed, as an integer.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
+>>> simulator.properties["max_shots"]       # doctest: +SKIP
+1000000
 
 .. _property_drsim_maximum_time_limit_s:
 
@@ -1581,11 +1644,11 @@ float.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
+>>> simulator.properties["maximum_time_limit_s"]    # doctest: +SKIP
+2700
 
 .. _property_drsim_minimum_time_limit_s:
 
@@ -1598,11 +1661,11 @@ float.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
+>>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
+>>> simulator.properties["minimum_time_limit_s"]    # doctest: +SKIP
+1
 
 .. _property_drsim_quota_conversion_rate:
 
@@ -1624,107 +1687,11 @@ See the :ref:`leap_hybrid_usage_charges` section for more information.
 Example
 -------
 
->>> from dwave.system import DWaveSampler
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> sampler = DWaveSampler()
->>> sampler.properties["default_readout_thermalization"]   # doctest: +SKIP
-0.0
-
-.. list-table::
-    :header-rows: 1
-
-    *   -   Property
-        -   Description
-        -   Type
-        -   Example Values
-    *   -   ``category``
-        -   Type of solver..
-        -   String
-        -   ``software-gate``: Gate-model simulator
-    *   -   ``default_noise_model``
-        -   Application of a noise model
-        -   Boolean
-        -   ``False``: No noise model is applied to the simulator
-    *   -   ``default_qpu``
-        -   QPU to simulate.
-        -   String
-        -   ``simulator``: Ideal simulator
-    *   -   ``default_repeat_until_shots_requested``
-        -   Repeatedly run the circuit to accumulate the requested number of
-            shots.
-        -   Boolean
-        -   ``False``: Executes the requested number of times
-    *   -   ``default_shots``
-        -   Number of times the circuit executes.
-        -   Integer
-        -   ``1``: Circuit executes once.
-    *   -   ``default_time_limit``
-        -   Requested run time in seconds.
-        -   Float
-        -   ``2700``: 45 minutes.
-    *   -   ``default_transpile``
-        -   Transpile the QCDL.
-        -   Boolean
-        -   ``True``: Transpile the QCDL.
-    *   -   ``max_shots``
-        -   Maximum times you can request that the circuit execute.
-        -   Integer
-        -   ``1,000,000``: Circuit executes a million times.
-    *   -   ``maximum_time_limit_s``
-        -   Maximum run time in seconds you can request.
-        -   Integer
-        -   ``2700``: 45 minutes.
-    *   -   ``minimum_time_limit_s``
-        -   Minimum run time in seconds you can request.
-        -   Integer
-        -   ``1``: One second.
-    *   -   ``quota_conversion_rate``
-        -   Rate at which user or project quota is consumed for the solver as a
-            ratio to QPU solver usage. Different solver types may consume quota
-            at different rates.
-
-            Time is deducted from your quota according to:
-
-            .. math::
-
-                \frac{num\_seconds}{quota\_conversion\_rate}
-
-            See the :ref:`leap_hybrid_usage_charges` section for more information.
-        -   Integer
-        -   ``1``: Same rate as QPU usage.
-    *   -   ``supported_problem_types``
-        -   Types of problems supported by this solver.
-        -   String
-        -   ``qcdl``: Solver supports programs formulated as QCDL.
-    *   -   ``supported_qpu_strings``
-        -   Target simulator modes.
-        -   String
-        -   ``simulator, DR17``: Ideal simulator and dual-rail simulator with 17
-            qubits.
-    *   -   ``version``
-        -   Software version of the simulator.
-        -   Float
-        -   ``0.1``: Version 0.1.
-
-
-
-.. _qcdl_submitting_programs:
-
-Submitting Programs
-===================
-
-The gate-model simulator in the |cloud|_ service is intended to simulate the
-dual-rail quantum computer by executing gate-model programs formulated as QCDL.
-
-The following documentation describes how to work with the |cloud|_ service:
-
-*   The :ref:`index_leap_sapi` section describes the |cloud|_ service.
-*   The :ref:`ocean_install` section explains how to install Ocean software.
-*   The :ref:`ocean_leap_authorization` section walks you through authorizing
-    your Ocean client to access the simulator in the |cloud|_ service.
-
-Example Submission
-------------------
+>>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
+>>> simulator.properties["quota_conversion_rate"]   # doctest: +SKIP
+1
 
 
 .. unsupported currently

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1275,42 +1275,147 @@ The following table compares these two simulation modes.
 Simulator Parameters
 --------------------
 
+.. _parameter_drsim_noise_model:
 
-.. list-table::
-    :header-rows: 1
+noise_model
+~~~~~~~~~~~
 
-    *   -   Option
-        -   Description
-        -   Type
-        -   Default
-    *   -   ``noise_model``
-        -   Sets the noise model. When ``True``, a conservative noise model is
-            applied.
-        -   Boolean
-        -   ``False``: No noise model is used
-    *   -   ``qpu``
-        -   The QPU to simulate. ``simulator`` simulates an ideal QPU while
-            ``DR17`` simulates a dual-rail QPU with 17 qubits.
-        -   string
-        -   ``simulator``
-    *   -   ``repeat_until_shots_requested``
-        -   Repeatedly run the circuit to accumulate the requested number of
-            shots.
-        -   Boolean
-        -   ``False`` (executes the requested number of times)
-    *   -   ``shots``
-        -   Number of times to run the circuit.
-        -   Integer
-        -   See the ``default_shots`` property
-    *   -   ``time_limit``
-        -   Maximum run time in seconds.
-        -   float
-        -   See the ``maximum_time_limit_s`` property
-    *   -   ``transpile``
-        -   Run the circuit verbatim or return an error if incompatible (when
-            ``transpile=False``).
-        -   Boolean
-        -   True
+Boolean flag that applies a noise model.
+
+*   ``noise_model=True``: Apply a noise model.
+*   ``noise_model=False``: Do not apply a noise model.
+
+Default is the value specified by the :ref:`property_drsim_default_noise_model`
+property.
+
+This example applies a noise model.
+
+>>> from dwave.system import EmbeddingComposite, DWaveSampler
+...
+>>> sampler = EmbeddingComposite(DWaveSampler())
+>>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
+>>> sampleset = sampler.sample_ising({}, J, num_reads=100,
+...                                  flux_drift_compensation=False)
+
+.. _parameter_drsim_qpu:
+
+qpu
+~~~
+
+The QPU to simulate, formatted as a string.
+
+Specified value must be one of the values of the
+:ref:`property_drsim_supported_qpu_strings` property.
+
+Default is to simulate the QPU specified by the
+:ref:`property_drsim_default_qpu` property.
+
+This example applies a noise model.
+
+>>> from dwave.system import EmbeddingComposite, DWaveSampler
+...
+>>> sampler = EmbeddingComposite(DWaveSampler())
+>>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
+>>> sampleset = sampler.sample_ising({}, J, num_reads=100,
+...                                  flux_drift_compensation=False)
+
+
+.. _parameter_drsim_repeat_until_shots_requested:
+
+repeat_until_shots_requested
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Boolean flag to run the circuit repeatedly until the requested number of
+measurements are accumulated.
+
+*   ``repeat_until_shots_requested=True``: Repeatedly run the circuit until
+    the requested number of measurements, set by the
+    :ref:`parameter_drsim_shots` parameter, is accumulated.
+*   ``repeat_until_shots_requested=False``: Run the circuit the number of times
+    set by the :ref:`parameter_drsim_shots` parameter.
+
+Default is to run the circuit the number of times set by the
+:ref:`parameter_drsim_shots` parameter.
+
+This example applies a noise model.
+
+>>> from dwave.system import EmbeddingComposite, DWaveSampler
+...
+>>> sampler = EmbeddingComposite(DWaveSampler())
+>>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
+>>> sampleset = sampler.sample_ising({}, J, num_reads=100,
+...                                  flux_drift_compensation=False)
+
+.. _parameter_drsim_shots:
+
+shots
+~~~~~
+
+The number of times to run the circuit, formatted as an integer.
+
+The specified value must not exceed the value of the
+:ref:`property_drsim_max_shots` property.
+
+Default is to run the circuit the number of times specified by the
+:ref:`property_drsim_default_shots` property.
+
+This example applies a noise model.
+
+>>> from dwave.system import EmbeddingComposite, DWaveSampler
+...
+>>> sampler = EmbeddingComposite(DWaveSampler())
+>>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
+>>> sampleset = sampler.sample_ising({}, J, num_reads=100,
+...                                  flux_drift_compensation=False)
+
+.. _parameter_drsim_time_limit:
+
+time_limit
+~~~~~~~~~~
+
+Specifies the maximum runtime, in seconds, the solver is allowed to work on the
+given program. Can be a float or integer.
+
+The specified time must be between the values of the
+:ref:`property_drsim_maximum_time_limit_s` and
+:ref:`property_drsim_minimum_time_limit_s` properties.
+
+Default is to run the circuit for the time specified by the
+:ref:`property_drsim_default_time_limit` property.
+
+This example applies a noise model.
+
+>>> from dwave.system import EmbeddingComposite, DWaveSampler
+...
+>>> sampler = EmbeddingComposite(DWaveSampler())
+>>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
+>>> sampleset = sampler.sample_ising({}, J, num_reads=100,
+...                                  flux_drift_compensation=False)
+
+.. _parameter_drsim_transpile:
+
+transpile
+~~~~~~~~~
+
+Boolean flag to rewrite the submitted QCDL circuit to use the QPU's supported
+basis gates and topology.
+
+*   ``transpile=True``: Transpile the circuit.
+*   ``transpile=False``: Run the circuit exactly as specified in the submitted
+    QCDL or return an error.
+
+Default is the value specified by the :ref:`property_drsim_default_transpile`
+property.
+
+This example applies a noise model.
+
+>>> from dwave.system import EmbeddingComposite, DWaveSampler
+...
+>>> sampler = EmbeddingComposite(DWaveSampler())
+>>> J = {('s1', 's2'): 0.5, ('s1', 's3'): 0.5, ('s2', 's3'): 0.5}
+>>> sampleset = sampler.sample_ising({}, J, num_reads=100,
+...                                  flux_drift_compensation=False)
+
 
 .. _qcdl_simulator_properties:
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1275,7 +1275,6 @@ The following table compares these two simulation modes.
 Simulator Parameters
 --------------------
 
-..  todo:: Update the rest once I can test in Leap
 
 .. list-table::
     :header-rows: 1
@@ -1318,6 +1317,81 @@ Simulator Parameters
 Simulator Properties
 --------------------
 
+.. list-table::
+    :header-rows: 1
+
+    *   -   Property
+        -   Description
+        -   Type
+        -   Example Values
+    *   -   ``category``
+        -   Type of solver..
+        -   String
+        -   ``software-gate``: Gate-model simulator
+    *   -   ``default_noise_model``
+        -   Application of a noise model
+        -   Boolean
+        -   ``False``: No noise model is applied to the simulator
+    *   -   ``default_qpu``
+        -   QPU to simulate.
+        -   String
+        -   ``simulator``: Ideal simulator
+    *   -   ``default_repeat_until_shots_requested``
+        -   Repeatedly run the circuit to accumulate the requested number of
+            shots.
+        -   Boolean
+        -   ``False``: Executes the requested number of times
+    *   -   ``default_shots``
+        -   Number of times the circuit executes.
+        -   Integer
+        -   ``1``: Circuit executes once.
+    *   -   ``default_time_limit``
+        -   Requested run time in seconds.
+        -   Float
+        -   ``2700``: 45 minutes.
+    *   -   ``default_transpile``
+        -   Transpile the QCDL.
+        -   Boolean
+        -   ``True``: Transpile the QCDL.
+    *   -   ``max_shots``
+        -   Maximum times you can request that the circuit execute.
+        -   Integer
+        -   ``1,000,000``: Circuit executes a million times.
+    *   -   ``maximum_time_limit_s``
+        -   Maximum run time in seconds you can request.
+        -   Integer
+        -   ``2700``: 45 minutes.
+    *   -   ``minimum_time_limit_s``
+        -   Minimum run time in seconds you can request.
+        -   Integer
+        -   ``1``: One second.
+    *   -   ``quota_conversion_rate``
+        -   Rate at which user or project quota is consumed for the solver as a
+            ratio to QPU solver usage. Different solver types may consume quota
+            at different rates.
+
+            Time is deducted from your quota according to:
+
+            .. math::
+
+                \frac{num\_seconds}{quota\_conversion\_rate}
+
+            See the :ref:`leap_hybrid_usage_charges` section for more information.
+        -   Integer
+        -   ``1``: Same rate as QPU usage.
+    *   -   ``supported_problem_types``
+        -   Types of problems supported by this solver.
+        -   String
+        -   ``qcdl``: Solver supports programs formulated as QCDL.
+    *   -   ``supported_qpu_strings``
+        -   Target simulator modes.
+        -   String
+        -   ``simulator, DR17``: Ideal simulator and dual-rail simulator with 17
+            qubits.
+    *   -   ``version``
+        -   Software version of the simulator.
+        -   Float
+        -   ``0.1``: Version 0.1.
 
 
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1410,8 +1410,9 @@ increased noise.
     parameter.
 *   ``repeat_until_shots_requested=False``: Run the circuit the number of times
     set by the :ref:`parameter_drsim_shots` parameter. Under noisy conditions,
-    fewer measurements than indicated by the :ref:`parameter_drsim_shots`
-    parameter might be accumulated with ``post_select=True``.
+    fewer non-erasure measurements than indicated by the
+    :ref:`parameter_drsim_shots` parameter might be accumulated with
+    ``post_select=True``.
 
 The default value is set by the
 :ref:`property_drsim_default_repeat_until_shots_requested` property.
@@ -1419,10 +1420,10 @@ The default value is set by the
 If runtime exceeds the value you specified in the
 :ref:`parameter_drsim_time_limit` parameter (or the default value of the
 :ref:`property_drsim_default_time_limit_s` property), execution
-terminates. The maximum number of times the circuit is run cannot exceed the
-value specified by the :ref:`property_drsim_maximum_shots` property.
+terminates.
 
-This example repeatedly executes the circuit to accumulate 10 measurements.
+This example repeatedly executes the circuit, under noisy conditions, to
+accumulate 10 non-erasure measurements.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1430,8 +1431,15 @@ This example repeatedly executes the circuit to accumulate 10 measurements.
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
 ...     shots=10,
+...     noise_model=True,
 ...     repeat_until_shots_requested=True)
 >>> result = future.result().result         # doctest: +SKIP
+
+The sum of non-splat states in the returned results is the requested number of
+shots:
+
+>>> print(sum(result.get_counts(post_select=True)[0].values())) # doctest: +SKIP
+10
 
 .. _parameter_drsim_shots:
 
@@ -1444,20 +1452,20 @@ Your QCDL program is executed once for each requested measurement.
 
 The specified value must not exceed the value of the
 :ref:`property_drsim_maximum_shots` property. Execution time is limited by the
-the value you specified in the :ref:`parameter_drsim_time_limit` parameter (or
+value you specified in the :ref:`parameter_drsim_time_limit` parameter (or
 the default value of the :ref:`property_drsim_default_time_limit_s` property).
 
 The default value is to measure the number of times specified by the
 :ref:`property_drsim_default_shots` property.
 
-This example executes the circuit 15 times.
+This example executes the circuit 1000 times.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     shots=15)
+...     shots=1000)
 >>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_time_limit:
@@ -1475,14 +1483,14 @@ The specified time must be between the values of the
 The default runtime limit is specified by the
 :ref:`property_drsim_default_time_limit_s` property.
 
-This example sets a maximum runtime of 20 seconds.
+This example sets a maximum runtime of 10 minutes.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     time_limit=20)
+...     time_limit=10*60)
 >>> result = future.result().result         # doctest: +SKIP
 
 .. _parameter_drsim_transpile:
@@ -1509,6 +1517,7 @@ simulator.
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
+...     noise_model=True,
 ...     transpile=False)
 >>> result = future.result().result         # doctest: +SKIP
 
@@ -1653,7 +1662,8 @@ Maximum number of qubits for QCDL circuits, as an integer.
 maximum_shots
 -------------
 
-Maximum number of times the circuit can be executed, as an integer.
+Maximum value of the :ref:`parameter_drsim_shots` you can specify, as an
+integer.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1679,9 +1679,7 @@ maximum_time_limit_s
 Maximum time, in seconds as a float, that your submitted circuit can run.
 
 This value limits the range of values you can set on the
-:ref:`parameter_drsim_time_limit` parameter and also limits the runtime allowed
-for a program submitted with the
-:ref:`parameter_drsim_repeat_until_shots_requested` set to true.
+:ref:`parameter_drsim_time_limit` parameter.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1209,7 +1209,7 @@ QPU Simulator
 =============
 
 the |cloud|_ service provides a Monte Carlo simulator of QCDL programs. This is
-an ideal simulator built on top of Qiskit's
+built on top of Qiskit's
 `AerStatevector <https://qiskit.github.io/qiskit-aer/stubs/qiskit_aer.quantum_info.AerStatevector.html>`_.
 
 This simulator closely models the classical and quantum operation of the QPU
@@ -1257,7 +1257,6 @@ following table compares these two simulation modes.
         -   Scales as :math:`O(s*g*2^n)` where :math:`n` is the number of qubits,
             :math:`s` the number of shots, and :math:`g` the number of gates.
 
-            Faster.
         -   Slower but same scaling.
     *   -   Supported gates.
         -   All gates available in Qiskit (no transpilation required).

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1317,7 +1317,7 @@ The example below submits the following
 Submit the program above to a simulator for a dual-rail QPU with 17 qubits,
 ``DRsim_17qubits``, in the |cloud|_ service.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
@@ -1352,7 +1352,7 @@ property.
 
 This example applies a noise model for the program submitted to the simulator.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
@@ -1374,7 +1374,7 @@ values. The default QPU to simulate is specified by the
 This example submits a QCDL program to a dual-rail QPU simulator with 21 qubits,
 ``DRsim_21qubits`` .
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
@@ -1425,7 +1425,7 @@ terminates.
 This example repeatedly executes the circuit, under noisy conditions, to
 accumulate 10 non-erasure measurements.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
@@ -1460,7 +1460,7 @@ The default value is to measure the number of times specified by the
 
 This example executes the circuit 1000 times.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
@@ -1485,7 +1485,7 @@ The default runtime limit is specified by the
 
 This example sets a maximum runtime of 10 minutes.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
@@ -1512,7 +1512,7 @@ property.
 This example requires that the QCDL circuit be submitted as written to the
 simulator.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
@@ -1536,7 +1536,7 @@ Type of solver, as a string.
 
 *   ``software-gate``: Gate-model simulator.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()     # doctest: +SKIP
 >>> simulator.properties["category"]    # doctest: +SKIP
@@ -1553,7 +1553,7 @@ Default setting for the application of a noise model, as a Boolean.
 *   ``False``: Simulates an ideal QPU, as described in the
     :ref:`qcdl_simulator` section.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["default_noise_model"]     # doctest: +SKIP
@@ -1569,7 +1569,7 @@ Default selection of the QPU to simulate, as a string.
 Supported QPUs are listed in the :ref:`property_drsim_supported_qpu_strings`
 property.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> simulator.properties["default_qpu"]     # doctest: +SKIP
@@ -1588,7 +1588,7 @@ include erasures (see the :ref:`qcdl_basic_result_records` section).
 *   ``False``: Run the circuit the number of times set by the
     :ref:`parameter_drsim_shots` parameter.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                                 # doctest: +SKIP
 >>> simulator.properties["default_repeat_until_shots_requested"]    # doctest: +SKIP
@@ -1603,7 +1603,7 @@ Default setting for the number of measurements to run (times to execute your
 QCDL circuit), as an integer. With dual-rail QPUs, a measurement result can be a
 "splat" (see the :ref:`qcdl_basic_measurements` section).
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> simulator.properties["default_shots"]   # doctest: +SKIP
@@ -1617,7 +1617,7 @@ default_time_limit_s
 Default maximum runtime, in seconds, the solver is allowed to work on the
 given program, as a float.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["default_time_limit_s"]      # doctest: +SKIP
@@ -1635,7 +1635,7 @@ the submitted QCDL program.
 *   ``False``: Run the circuit exactly as specified in the submitted
     QCDL or return an error.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["default_transpile"]       # doctest: +SKIP
@@ -1651,7 +1651,7 @@ Maximum number of qubits for QCDL circuits, as an integer.
 .. note:: :ref:`Transpilation <qcdl_basic_transpilation>` can add and remove
     qubits in your QCDL.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                     # doctest: +SKIP
 >>> simulator.properties["maximum_num_qubits"]          # doctest: +SKIP
@@ -1665,7 +1665,7 @@ maximum_shots
 Maximum value of the :ref:`parameter_drsim_shots` you can specify, as an
 integer.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()             # doctest: +SKIP
 >>> simulator.properties["maximum_shots"]       # doctest: +SKIP
@@ -1681,7 +1681,7 @@ Maximum time, in seconds as a float, that your submitted circuit can run.
 This value limits the range of values you can set on the
 :ref:`parameter_drsim_time_limit` parameter.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["maximum_time_limit_s"]    # doctest: +SKIP
@@ -1694,7 +1694,7 @@ minimum_shots
 
 Minimum number of times the circuit can be executed, as an integer.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()             # doctest: +SKIP
 >>> simulator.properties["minimum_shots"]       # doctest: +SKIP
@@ -1708,7 +1708,7 @@ minimum_time_limit_s
 Minimum time, in seconds as a float, you can specify for the runtime limit (the
 :ref:`parameter_drsim_time_limit` parameter) on your submitted circuit.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["minimum_time_limit_s"]    # doctest: +SKIP
@@ -1730,7 +1730,7 @@ Time is deducted from your quota according to:
 
 See the :ref:`leap_hybrid_usage_charges` section for more information.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["quota_conversion_rate"]   # doctest: +SKIP
@@ -1748,7 +1748,7 @@ Available QPUs are the following:
 *   ``DRsim_17qubits``: Dual-rail QPU with 17 qubits.
 *   ``DRsim_21qubits``: Dual-rail QPU with 21 qubits.
 
->>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+>>> from dwave.gate.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["supported_qpu_strings"]   # doctest: +SKIP

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -167,11 +167,6 @@ transpilation collapses your QCDL.
         barrier(q0)
         x(q0)
 
-.. note::
-    A :func:`~dwave.gate.qcdl.operations.barrier` instruction does not necessarily
-    imply a :meth:`~dwave.gate.qcdl.QCDLModuleContainer.sync` (see the
-    :ref:`qcdl_advanced_synchronization` section).
-
 .. [#]
     When the transpiler is not used, the :func:`~dwave.gate.qcdl.operations.barrier`
     instruction might affect some circuit modifications.
@@ -1235,6 +1230,8 @@ number of shots; however, its operation is
         registers before simulating reduced-precision registers; start with
         ideal quantum operations before introducing erasures.
 
+        Amos: Update the above paragraph as new features become available
+
 The simulator in the |cloud|_ service supports two modes of simulations. The
 following table compares these two simulation modes.
 
@@ -1257,7 +1254,8 @@ following table compares these two simulation modes.
             QCDL programs. It operates by randomly applying Pauli errors,
             leakages, and seepages after quantum gates and idles.
     *   -   Runtime.
-        -   Scales as :math:`O(2^n)` where :math:`n` is the number of qubits.
+        -   Scales as :math:`O(s*g*2^n)` where :math:`n` is the number of qubits,
+            :math:`s` the number of shots, and :math:`g` the number of gates.
 
             Faster.
         -   Slower but same scaling.
@@ -1265,7 +1263,7 @@ following table compares these two simulation modes.
         -   All gates available in Qiskit (no transpilation required).
         -   Subset of gates (transpilation required).
     *   -   Support for errors.
-        -   No support.
+        -   No support. (Returns :math:`0` for ``mced``, signifying no leak.)
         -   Supports the ``mced`` instruction to detect if the qubit has been
             erased, and the ``leak`` and ``seep`` instructions to simulate
             leakage and seepage errors.
@@ -1324,6 +1322,11 @@ Submit the program above to a simulator for a dual-rail QPU with 17 qubits,
 ...     simulator_job_submission,
 ...     qpu='DRsim_17qubits')
 >>> result = future.result().result         # doctest: +SKIP
+
+The returned result is a 3D array of ``(measurements per shot, shots, qubits)``.
+
+>>> print(result.get_memory().shape)        # doctest: +SKIP
+(1, 1000, 2)
 
 .. todo:: describe the results
 
@@ -1399,7 +1402,7 @@ post-selection to remove "splats" (see the :ref:`qcdl_basic_result_records`
 section), you can select to repeatedly run the circuit. With yield defined as
 the percentage of shots without erasures, the required number of executions (and
 runtime) is proportional to the value of the :ref:`parameter_drsim_shots`
-parameter and the reciprocal of the yield, and can grow exponentially with
+parameter and the reciprocal of the yield, and grows exponentially with
 increased noise.
 
 *   ``repeat_until_shots_requested=True``: Repeatedly run the circuit until

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1228,28 +1228,15 @@ number of shots; however, its operation is
 .. tip::
     Accuracy bears a simulation cost and error handling increases circuit
     complexity. It is advisable to start circuit development against the ideal
-    simulator and then introduce error modeling in a controlled way. For
-    example, start by simulating full-precision registers before simulating
-    reduced-precision registers; start with ideal quantum operations before
-    introducing erasures.
+    simulator and then introduce error modeling.
 
-The simulator in the |cloud|_ service supports two modes of simulations:
+    .. for future consideration
+        in a controlled way. For example, start by simulating full-precision
+        registers before simulating reduced-precision registers; start with
+        ideal quantum operations before introducing erasures.
 
-*   Statevector Simulation (solver parameter :ref:`parameter_drsim_noise_model`
-    set to ``False``)
-
-    This simulation is useful during initial testing of
-    QCDL programs before introducing noise.
-*   Dual-Rail Erasure Simulation (solver parameter
-    :ref:`parameter_drsim_noise_model` set to ``True``)
-
-    This simulation is useful for exploring the impact of erasures on QCDL
-    programs. It represents the quantum state as a Statevector with an array of
-    booleans (which mark whether a qubit has leaked or not). It operates by
-    randomly applying Pauli errors, leakages, and seepages after quantum gates
-    and idles.
-
-The following table compares these two simulation modes.
+The simulator in the |cloud|_ service supports two modes of simulations. The
+following table compares these two simulation modes.
 
 .. list-table::
     :header-rows: 1
@@ -1257,12 +1244,26 @@ The following table compares these two simulation modes.
     *   -   Characteristic
         -   Statevector Simulation
         -   Dual-Rail Erasure Simulation
+    *   -   Noise model.
+        -   Solver parameter :ref:`parameter_drsim_noise_model` set to
+            ``False``.
+
+            Useful during initial testing of QCDL programs before introducing
+            noise.
+        -   Solver parameter :ref:`parameter_drsim_noise_model` set to
+            ``True``.
+
+            This simulation is useful for exploring the impact of erasures on
+            QCDL programs. It operates by randomly applying Pauli errors,
+            leakages, and seepages after quantum gates and idles.
     *   -   Runtime.
         -   Scales as :math:`O(2^n)` where :math:`n` is the number of qubits.
-        -   Slightly slower than statevector simulation but same scaling.
+
+            Faster.
+        -   Slower but same scaling.
     *   -   Supported gates.
         -   All gates available in Qiskit (no transpilation required).
-        -   Subset of basis gates (transpilation required).
+        -   Subset of gates (transpilation required).
     *   -   Support for errors.
         -   No support.
         -   Supports the ``mced`` instruction to detect if the qubit has been
@@ -1270,13 +1271,15 @@ The following table compares these two simulation modes.
             leakage and seepage errors.
 
 
+
 .. _qcdl_submitting_programs:
 
 Submitting Programs
 ===================
 
-The gate-model simulator in the |cloud|_ service is intended to simulate the
-dual-rail quantum computer by executing gate-model programs formulated as QCDL.
+The :ref:`QPU simulator <qcdl_simulator>` in the |cloud|_ service is intended to
+simulate :ref:`gate-model quantum computers <qpu_gate_model_intro>` by executing
+programs formulated as QCDL.
 
 The following documentation describes how to work with the |cloud|_ service:
 
@@ -1368,15 +1371,15 @@ The :ref:`property_drsim_supported_qpu_strings` property lists the supported
 values. The default QPU to simulate is specified by the
 :ref:`property_drsim_default_qpu` property.
 
-This example submits a QCDL program to a dual-rail QPU simulator with 17 qubits,
-``DRsim_17qubits`` .
+This example submits a QCDL program to a dual-rail QPU simulator with 21 qubits,
+``DRsim_21qubits`` .
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> future = simulator.run(                 # doctest: +SKIP
 ...     simulator_job_submission,
-...     qpu='DRsim_17qubits')
+...     qpu='DRsim_21qubits')
 >>> result = future.result().result         # doctest: +SKIP
 
 
@@ -1385,20 +1388,30 @@ This example submits a QCDL program to a dual-rail QPU simulator with 17 qubits,
 repeat_until_shots_requested
 ----------------------------
 
-Boolean flag to run the circuit repeatedly until the requested number of
-measurements, set by the :ref:`parameter_drsim_shots` parameter, are
-accumulated, even under noisy conditions, where the accumulated measurements do
-not include erasures (see the :ref:`qcdl_basic_result_records` section).
+Boolean flag to run the circuit repeatedly until a target number of
+non-erased measurements are accumulated.
+
+Running a circuit might return, under noisy conditions, measurements that are
+declared to be “erased”, as described in the :ref:`qcdl_basic_measurements`
+section. To try to achieve the required number of non-erasure measurements
+indicted by the :ref:`parameter_drsim_shots` parameter, as counted after
+post-selection to remove "splats" (see the :ref:`qcdl_basic_result_records`
+section), you can select to repeatedly run the circuit. With yield defined as
+the percentage of shots without erasures, the required number of executions (and
+runtime) is proportional to the value of the :ref:`parameter_drsim_shots`
+parameter and the reciprocal of the yield, and can grow exponentially with
+increased noise.
 
 *   ``repeat_until_shots_requested=True``: Repeatedly run the circuit until
-    the requested number of measurements, set by the
-    :ref:`parameter_drsim_shots` parameter, is accumulated. Under noisy
-    conditions the circuit might be executed a greater number of times than set
-    by the :ref:`parameter_drsim_shots` parameter.
+    the requested number of non-erasure measurements, indicated by the
+    :ref:`parameter_drsim_shots` parameter, is accumulated with
+    ``post_select=True``. Under noisy conditions the circuit might be executed a
+    greater number of times than set by the :ref:`parameter_drsim_shots`
+    parameter.
 *   ``repeat_until_shots_requested=False``: Run the circuit the number of times
     set by the :ref:`parameter_drsim_shots` parameter. Under noisy conditions,
-    fewer measurements than requested by the :ref:`parameter_drsim_shots`
-    parameter might be accumulated.
+    fewer measurements than indicated by the :ref:`parameter_drsim_shots`
+    parameter might be accumulated with ``post_select=True``.
 
 The default value is set by the
 :ref:`property_drsim_default_repeat_until_shots_requested` property.
@@ -1585,7 +1598,7 @@ QCDL circuit), as an integer. With dual-rail QPUs, a measurement result can be a
 ...
 >>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
 >>> simulator.properties["default_shots"]   # doctest: +SKIP
-1
+1000
 
 .. _property_drsim_default_time_limit_s:
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1207,57 +1207,14 @@ Guidance on Mirroring
     :func:`~dwave.gate.implementations.mirror_measurement_register`
     functions
 
-.. _qcdl_submitting_programs:
 
-Submitting Programs
-===================
-
-.. todo:: add references to places such as
-    https://docs.dwavequantum.com/en/latest/quantum_research/index_get_started.html
-
-.. unsupported currently
-
-    .. _qcdl_submitting_compiling:
-
-    Compilation
-    -----------
-
-    Compilation is required to submit a circuit to a QPU. The compiled artifact is a
-    ``.jmz`` file.
-
-    .. note::
-        Submitting to a QPU is currently not supported.
-
-    You do not need to compile if you are submitting your QCDL to a simulator, but
-    is useful if you wish to validate that your circuit could run on a QPU. You may
-    choose to compile to perform a more comprehensive validation of your QCDL
-    on the simulator, to ensure both that the program returns the correct results
-    and that the compiler is able to generate a set of instructions for the QPU to
-    correctly execute. Compilation takes some extra time and you probably do not
-    need to compile each simulation.
-
-    .. tip::
-        Compile immediately prior to every execution on a QPU to ensure the latest
-        calibrated parameters are used. Some applications may be able to reuse a
-        previously compiled ``.jmz`` to save time but ``.jmz`` files may expire.
-
-Execution
----------
-
-.. compilation unsupported currently
-
-    You can simulate either the QCDL itself directly or a compiled version of the
-    QCDL (a ``.jmz`` file).
-
-.. todo:: update for Ocean
-
-.. _qcdl_submitting_simulator:
+.. _qcdl_simulator:
 
 Simulator
----------
+=========
 
-Ocean software provides a Monte Carlo simulator of QCDL programs. This is an
-ideal simulator built on top of Qiskit's
+the |cloud|_ service provides a Monte Carlo simulator of QCDL programs. This is
+an ideal simulator built on top of Qiskit's
 `AerStatevector <https://qiskit.github.io/qiskit-aer/stubs/qiskit_aer.quantum_info.AerStatevector.html>`_.
 
 This simulator closely models the classical and quantum operation of the QPU
@@ -1278,11 +1235,11 @@ number of shots; however, its operation is
 
 The simulator in the |cloud|_ service supports two modes of simulations:
 
-*   Statevector Simulation
+*   Statevector Simulation (solver parameter `qpu=simulator`)
 
     This simulation is useful during initial testing of
     QCDL programs before introducing noise.
-*   Dual-Rail Erasure Simulation
+*   Dual-Rail Erasure Simulation (solver parameter `qpu=DR17`)
 
     This simulation is useful for exploring the impact of erasures on QCDL
     programs. It represents the quantum state as a Statevector with an array of
@@ -1313,8 +1270,10 @@ The following table compares these two simulation modes.
             erased, and the ``leak`` and ``seep`` instructions to simulate
             leakage and seepage errors.
 
-Simulator Configuration
-~~~~~~~~~~~~~~~~~~~~~~~
+.. _qcdl_simulator_parameters:
+
+Simulator Parameters
+--------------------
 
 ..  todo:: Update the rest once I can test in Leap
 
@@ -1325,24 +1284,90 @@ Simulator Configuration
         -   Description
         -   Type
         -   Default
-    *   -   ``transpile``
-        -   To run the circuit verbatim (error if incompatible), set
-            ``transpile=False``.
-        -   bool
-        -   True
-    *   -   ``timeout``
-        -   For faster feedback, use a lower timeout (in seconds) when
-            troubleshooting circuits with loops.
-        -   float
-        -   45 minutes
     *   -   ``noise_model``
-        -   If ``noise_model=None``, no noise model is used; otherwise, specify
-            the name of the noise model to use.
-        -   ``None``, ``"conservative_c8"``, ``"simple_default_model"``
-        -   ``"conservative_c8"``
-    *   -   ``use_registers``
-        -   If true, the bit-width restrictions are simulated; otherwise, the
-            classical calculations are done in full precision.
-        -   bool
-        -   False
+        -   Sets the noise model. When ``True``, a conservative noise model is
+            applied.
+        -   Boolean
+        -   ``False``: No noise model is used
+    *   -   ``qpu``
+        -   The QPU to simulate. ``simulator`` simulates an ideal QPU while
+            ``DR17`` simulates a dual-rail QPU with 17 qubits.
+        -   string
+        -   ``simulator``
+    *   -   ``repeat_until_shots_requested``
+        -   Repeatedly run the circuit to accumulate the requested number of
+            shots.
+        -   Boolean
+        -   ``False`` (executes the requested number of times)
+    *   -   ``shots``
+        -   Number of times to run the circuit.
+        -   Integer
+        -   See the ``default_shots`` property
+    *   -   ``time_limit``
+        -   Maximum run time in seconds.
+        -   float
+        -   See the ``maximum_time_limit_s`` property
+    *   -   ``transpile``
+        -   Run the circuit verbatim or return an error if incompatible (when
+            ``transpile=False``).
+        -   Boolean
+        -   True
+
+.. _qcdl_simulator_properties:
+
+Simulator Properties
+--------------------
+
+
+
+
+.. _qcdl_submitting_programs:
+
+Submitting Programs
+===================
+
+The gate-model simulator in the |cloud|_ service is intended to simulate the
+dual-rail quantum computer by executing gate-model programs formulated as QCDL.
+
+The following documentation describes how to work with the |cloud|_ service:
+
+*   The :ref:`index_leap_sapi` section describes the |cloud|_ service.
+*   The :ref:`ocean_install` section explains how to install Ocean software.
+*   The :ref:`ocean_leap_authorization` section walks you through authorizing
+    your Ocean client to access the simulator in the |cloud|_ service.
+
+Example Submission
+------------------
+
+
+.. unsupported currently
+
+    .. _qcdl_submitting_compiling:
+
+    Compilation
+    -----------
+
+    Compilation is required to submit a circuit to a QPU. The compiled artifact is a
+    ``.jmz`` file.
+
+    .. note::
+        Submitting to a QPU is currently not supported.
+
+    You do not need to compile if you are submitting your QCDL to a simulator, but
+    is useful if you wish to validate that your circuit could run on a QPU. You may
+    choose to compile to perform a more comprehensive validation of your QCDL
+    on the simulator, to ensure both that the program returns the correct results
+    and that the compiler is able to generate a set of instructions for the QPU to
+    correctly execute. Compilation takes some extra time and you probably do not
+    need to compile each simulation.
+
+    .. tip::
+        Compile immediately prior to every execution on a QPU to ensure the latest
+        calibrated parameters are used. Some applications may be able to reuse a
+        previously compiled ``.jmz`` to save time but ``.jmz`` files may expire.
+
+.. compilation unsupported currently
+
+    You can simulate either the QCDL itself directly or a compiled version of the
+    QCDL (a ``.jmz`` file).
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1261,7 +1261,7 @@ The following table compares these two simulation modes.
         -   Scales as :math:`O(2^n)` where :math:`n` is the number of qubits.
         -   Slightly slower than statevector simulation but same scaling.
     *   -   Supported gates.
-        -   All basis gates available in Qiskit (no transpilation require).
+        -   All gates available in Qiskit (no transpilation required).
         -   Subset of basis gates (transpilation required).
     *   -   Support for errors.
         -   No support.
@@ -1364,12 +1364,8 @@ qpu
 
 The QPU to simulate, formatted as a string.
 
-The following values are supported:
-
-*   ``DRsim_17qubits``: Dual-rail QPU with 17 qubits.
-*   ``DRsim_21qubits``: Dual-rail QPU with 21 qubits.
-
-The default QPU to simulate is specified by the
+The :ref:`property_drsim_supported_qpu_strings` property lists the supported
+values. The default QPU to simulate is specified by the
 :ref:`property_drsim_default_qpu` property.
 
 This example submits a QCDL program to a dual-rail QPU simulator with 17 qubits,
@@ -1408,10 +1404,10 @@ The default value is set by the
 :ref:`property_drsim_default_repeat_until_shots_requested` property.
 
 If runtime exceeds the value you specified in the
-:ref:`parameter_drsim_time_limit` parameter, or the maximum allowed runtime
-value of the :ref:`property_drsim_maximum_time_limit_s` property, execution
+:ref:`parameter_drsim_time_limit` parameter (or the default value of the
+:ref:`property_drsim_default_time_limit_s` property), execution
 terminates. The maximum number of times the circuit is run cannot exceed the
-value specified by the :ref:`property_drsim_max_shots` property.
+value specified by the :ref:`property_drsim_maximum_shots` property.
 
 This example repeatedly executes the circuit to accumulate 10 measurements.
 
@@ -1434,10 +1430,9 @@ The number of measurements to run, formatted as an integer.
 Your QCDL program is executed once for each requested measurement.
 
 The specified value must not exceed the value of the
-:ref:`property_drsim_max_shots` property. Execution time is limited by the
-the value you specified in the :ref:`parameter_drsim_time_limit` parameter, or
-the maximum allowed runtime value of the
-:ref:`property_drsim_maximum_time_limit_s` property.
+:ref:`property_drsim_maximum_shots` property. Execution time is limited by the
+the value you specified in the :ref:`parameter_drsim_time_limit` parameter (or
+the default value of the :ref:`property_drsim_default_time_limit_s` property).
 
 The default value is to measure the number of times specified by the
 :ref:`property_drsim_default_shots` property.
@@ -1465,7 +1460,7 @@ The specified time must be between the values of the
 :ref:`property_drsim_minimum_time_limit_s` properties.
 
 The default runtime limit is specified by the
-:ref:`property_drsim_default_time_limit` property.
+:ref:`property_drsim_default_time_limit_s` property.
 
 This example sets a maximum runtime of 20 seconds.
 
@@ -1549,8 +1544,8 @@ default_qpu
 
 Default selection of the QPU to simulate, as a string.
 
-*   ``DRsim_17qubits``: Dual-rail QPU with 17 qubits.
-*   ``DRsim_21qubits``: Dual-rail QPU with 21 qubits.
+Supported QPUs are listed in the :ref:`property_drsim_supported_qpu_strings`
+property.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
@@ -1592,10 +1587,10 @@ QCDL circuit), as an integer. With dual-rail QPUs, a measurement result can be a
 >>> simulator.properties["default_shots"]   # doctest: +SKIP
 1
 
-.. _property_drsim_default_time_limit:
+.. _property_drsim_default_time_limit_s:
 
-default_time_limit
-------------------
+default_time_limit_s
+--------------------
 
 Default maximum runtime, in seconds, the solver is allowed to work on the
 given program, as a float.
@@ -1603,7 +1598,7 @@ given program, as a float.
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
->>> simulator.properties["default_time_limit"]      # doctest: +SKIP
+>>> simulator.properties["default_time_limit_s"]      # doctest: +SKIP
 2700
 
 .. _property_drsim_default_transpile:
@@ -1624,10 +1619,10 @@ the submitted QCDL program.
 >>> simulator.properties["default_transpile"]       # doctest: +SKIP
 True
 
-.. _property_drsim_max_num_qubits:
+.. _property_drsim_maximum_num_qubits:
 
-max_num_qubits
---------------
+maximum_num_qubits
+------------------
 
 Maximum number of qubits for QCDL circuits, as an integer.
 
@@ -1636,21 +1631,21 @@ Maximum number of qubits for QCDL circuits, as an integer.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
->>> simulator.properties["max_num_qubits"]       # doctest: +SKIP
+>>> simulator = LeapQCDLSimulator()                     # doctest: +SKIP
+>>> simulator.properties["maximum_num_qubits"]          # doctest: +SKIP
 21
 
-.. _property_drsim_max_shots:
+.. _property_drsim_maximum_shots:
 
-max_shots
----------
+maximum_shots
+-------------
 
 Maximum number of times the circuit can be executed, as an integer.
 
 >>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
 ...
->>> simulator = LeapQCDLSimulator()         # doctest: +SKIP
->>> simulator.properties["max_shots"]       # doctest: +SKIP
+>>> simulator = LeapQCDLSimulator()             # doctest: +SKIP
+>>> simulator.properties["maximum_shots"]       # doctest: +SKIP
 1000000
 
 .. _property_drsim_maximum_time_limit_s:
@@ -1670,6 +1665,19 @@ for a program submitted with the
 >>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
 >>> simulator.properties["maximum_time_limit_s"]    # doctest: +SKIP
 2700
+
+.. _property_drsim_minimum_shots:
+
+minimum_shots
+-------------
+
+Minimum number of times the circuit can be executed, as an integer.
+
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+...
+>>> simulator = LeapQCDLSimulator()             # doctest: +SKIP
+>>> simulator.properties["minimum_shots"]       # doctest: +SKIP
+1
 
 .. _property_drsim_minimum_time_limit_s:
 
@@ -1707,6 +1715,23 @@ See the :ref:`leap_hybrid_usage_charges` section for more information.
 >>> simulator.properties["quota_conversion_rate"]   # doctest: +SKIP
 1
 
+.. _property_drsim_supported_qpu_strings:
+
+supported_qpu_strings
+---------------------
+
+Names of supported simulators, as a list of strings.
+
+Available QPUs are the following:
+
+*   ``DRsim_17qubits``: Dual-rail QPU with 17 qubits.
+*   ``DRsim_21qubits``: Dual-rail QPU with 21 qubits.
+
+>>> from dwave.gate.qcdl.leap import LeapQCDLSimulator
+...
+>>> simulator = LeapQCDLSimulator()                 # doctest: +SKIP
+>>> simulator.properties["supported_qpu_strings"]   # doctest: +SKIP
+['DRsim_17qubits', 'DRsim_21qubits']
 
 .. unsupported currently
 


### PR DESCRIPTION
I will update the existing QCDL for `dwave-gate` job submission and result handling in a second PR, creating this one now to give reviewers time. 

@jstubbs-dwave
